### PR TITLE
fix: Use String:from_utf8_lossy to print output in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     f.write_all(&output.stdout).unwrap();
 
-    println!("{:?}", output.stderr);
+    println!("{}", String::from_utf8_lossy(&output.stderr));
 
     let output = Command::new(py_cmd)
         .arg(&format!("{}/icon3.py", bolos_sdk))
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut f = File::create(&dest_path.join("glyphs.h")).unwrap();
     f.write_all(&output.stdout).unwrap();
 
-    println!("{:?}", output.stderr);
+    println!("{}", String::from_utf8_lossy(&output.stderr));
     assert!(output.status.success());
 
     cc::Build::new()


### PR DESCRIPTION
## Description

Currently `println!("{:?}", output.stderr);` will print the bytes as a `[u8,u8]`. Use `String::from_utf8_lossy` to convert to a readable string for better debugging.