### PR TITLE
Fix #11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ lto = true
 
 [features]
 speculos = []
+pre1_54 = []

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ required.
 - install [Clang](http://releases.llvm.org/download.html).
 - install an [ARM GCC toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
 
+### Building with rustc < 1.54
+
+Building before rustc 1.54 should fail with `error[E0635]: unknown feature const_fn_trait_bound`.
+
+This is solved by activating a specific feature: `cargo build --features pre1_54`
+
 ## Contributing
 
 Make sure you've followed the installation steps above. In order for your PR to be accepted, it will have to pass the CI, which performs the following checks:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(const_fn)]
 #![feature(asm)]
 #![feature(const_panic)]
+#![cfg_attr(not(feature = "pre1_54"), feature(const_fn_trait_bound))]
 
 pub mod bindings;
 pub mod buttons;


### PR DESCRIPTION
Activates `const_fn_trait_bound` by default, and introduces a feature (`pre1_54`) that deactivates it when needed (using a nightly compiler prior to version 1.54)