### PR TITLE
Remove bindings consts if defined in build.rs

### DIFF
--- a/binding_headers/bindings.h
+++ b/binding_headers/bindings.h
@@ -48,11 +48,7 @@
 #define HAVE_ECDSA
 #define HAVE_EDDSA
 #define HAVE_ECSCHNORR
-#define IO_HID_EP_LENGTH 50
-#define OS_IO_SEPROXYHAL
-#define IO_SEPROXYHAL_BUFFER_SIZE_B 300
 #define HAVE_IO_USB
-#define IO_USB_MAX_ENDPOINTS 6
 #include "os.h"
 #include "os_io_seproxyhal.h"
 #include "libcxng.h"

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -85,8 +85,6 @@ where
         }
     }
 }
-pub const IO_HID_EP_LENGTH: u32 = 50;
-pub const IO_SEPROXYHAL_BUFFER_SIZE_B: u32 = 300;
 pub const TARGET_ID: u32 = 823132164;
 pub const __NVIC_PRIO_BITS: u32 = 2;
 pub const __Vendor_SysTickConfig: u32 = 0;


### PR DESCRIPTION
This prevents potential mismatches between the cc-compiled SDK and actual bindings