### PR TITLE
Make CI run on all pull request pushes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      master
   pull_request:
-    branches: [ master ]
   workflow_dispatch:
     inputs: 
       name: 


### PR DESCRIPTION
Run on all PRs, not just PRs against `master`.