### PR TITLE
Use "nicer" cfgs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,6 @@ use std::process::Command;
 use std::{env, error::Error, fs::File, io::Read};
 
 fn finalize_nanos_configuration(command: &mut cc::Build, bolos_sdk: &String) -> String {
-    println!("cargo:rustc-cfg=nanos");
     command
         .target("thumbv6m-none-eabi")
         .define("ST31", None)
@@ -25,7 +24,6 @@ fn finalize_nanos_configuration(command: &mut cc::Build, bolos_sdk: &String) -> 
 }
 
 fn finalize_nanox_configuration(command: &mut cc::Build, bolos_sdk: &String) -> String {
-    println!("cargo:rustc-cfg=nanox");
     command
         .target("thumbv6m-none-eabi")
         .define("ST33", None)
@@ -86,7 +84,6 @@ fn finalize_nanox_configuration(command: &mut cc::Build, bolos_sdk: &String) -> 
 }
 
 fn finalize_nanosplus_configuration(command: &mut cc::Build, bolos_sdk: &String) -> String {
-    println!("cargo:rustc-cfg=nanosplus");
     command
         .target("thumbv8m.main-none-eabi")
         .define("ST33K1M5", None)

--- a/nanos.json
+++ b/nanos.json
@@ -20,5 +20,7 @@
   },
   "relocation-model": "ropi",
   "singlethread": true,
-  "target-pointer-width": "32"
+  "target-pointer-width": "32",
+  "os": "nanos",
+  "target-family": [ "bolos" ]
 }

--- a/nanosplus.json
+++ b/nanosplus.json
@@ -19,5 +19,7 @@
   },
   "relocation-model": "ropi-rwpi",
   "singlethread": true,
-  "target-pointer-width": "32"
+  "target-pointer-width": "32",
+  "os": "nanosplus",
+  "target-family": [ "bolos" ]
 }

--- a/nanox.json
+++ b/nanox.json
@@ -19,5 +19,8 @@
   },
   "relocation-model": "ropi-rwpi",
   "singlethread": true,
-  "target-pointer-width": "32"
+  "target-pointer-width": "32",
+  "os": "nanox",
+  "target-family": [ "bolos" ]
+
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,5 +1,5 @@
 use crate::bindings::*;
-#[cfg(nanox)]
+#[cfg(target_os = "nanox")]
 use crate::ble;
 use crate::buttons::{get_button_event, ButtonEvent, ButtonsState};
 
@@ -136,7 +136,7 @@ impl Comm {
                 seph::seph_send(&[seph::SephTags::RawAPDU as u8, len[0], len[1]]);
                 seph::seph_send(&self.apdu_buffer[..self.tx]);
             }
-            #[cfg(nanox)]
+            #[cfg(target_os = "nanox")]
             APDU_BLE => {
                 ble::send(&self.apdu_buffer[..self.tx]);
             }
@@ -266,7 +266,7 @@ impl Comm {
                     seph::handle_capdu_event(&mut self.apdu_buffer, &spi_buffer)
                 }
 
-                #[cfg(nanox)]
+                #[cfg(target_os = "nanox")]
                 seph::Events::BleReceive => ble::receive(&mut self.apdu_buffer, &spi_buffer),
 
                 seph::Events::TickerEvent => return Event::Ticker,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 
 pub mod bindings;
 
-#[cfg(nanox)]
+#[cfg(target_os = "nanox")]
 pub mod ble;
 
 pub mod buttons;

--- a/src/nvm.rs
+++ b/src/nvm.rs
@@ -184,11 +184,11 @@ macro_rules! atomic_storage {
     };
 }
 
-#[cfg(nanos)]
+#[cfg(target_os = "nanos")]
 atomic_storage!(64);
-#[cfg(nanox)]
+#[cfg(target_os = "nanox")]
 atomic_storage!(256);
-#[cfg(nanosplus)]
+#[cfg(target_os = "nanosplus")]
 atomic_storage!(512);
 
 pub enum AtomicStorageElem {

--- a/src/seph.rs
+++ b/src/seph.rs
@@ -3,7 +3,7 @@
 use crate::bindings::*;
 use crate::usbbindings::*;
 
-#[cfg(nanox)]
+#[cfg(target_os = "nanox")]
 use crate::ble;
 
 #[repr(u8)]
@@ -245,7 +245,7 @@ pub fn handle_event(apdu_buffer: &mut [u8], spi_buffer: &[u8]) {
                 handle_usb_ep_xfer_event(apdu_buffer, spi_buffer);
             }
         }
-        #[cfg(nanox)]
+        #[cfg(target_os = "nanox")]
         Events::BleReceive => ble::receive(apdu_buffer, spi_buffer),
         Events::CAPDUEvent => handle_capdu_event(apdu_buffer, spi_buffer),
         Events::TickerEvent => { /* unsafe{ G_io_app.ms += 100; } */ }


### PR DESCRIPTION
Instead of hacking in the specific device in the `build.rs`, which doesn't work for downstream packages, specify it as the "os" in the target json. Also specify "bolos" as a `target_family` to make a catch-all `cfg` for any Ledger device easy too.