### PR TITLE
Use #38 in build.rs and structure

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -182,16 +182,28 @@ fn main() -> Result<(), Box<dyn Error>> {
         .flag("-Wno-unused-command-line-argument")
         .clone();
 
-    // determine target
-    let target = env::var_os("TARGET");
-    let cx_makefile = match target.clone().unwrap().to_str().unwrap() {
-        "nanos" => finalize_nanos_configuration(&mut command, &bolos_sdk),
-        "nanox" => finalize_nanox_configuration(&mut command, &bolos_sdk),
-        "nanosplus" => finalize_nanosplus_configuration(&mut command, &bolos_sdk),
+    enum Device {
+        NanoS,
+        NanoSPlus,
+        NanoX,
+    }
+    use Device::*;
+
+    // determine device
+    let device = match env::var_os("CARGO_CFG_TARGET_OS").unwrap().to_str().unwrap() {
+        "nanos" => NanoS,
+        "nanosplus" => NanoSPlus,
+        "nanox" => NanoX,
         target_name => panic!(
             "invalid target `{}`, expected one of `nanos`, `nanox`, `nanosplus`. Run with `-Z build-std=core --target=./<target name>.json`",
             target_name
         ),
+    };
+
+    let cx_makefile = match NanoS {
+        NanoS => finalize_nanos_configuration(&mut command, &bolos_sdk),
+        NanoX => finalize_nanox_configuration(&mut command, &bolos_sdk),
+        NanoSPlus => finalize_nanosplus_configuration(&mut command, &bolos_sdk),
     };
 
     // all 'finalize_...' functions also declare a new 'cfg' variable corresponding
@@ -225,11 +237,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     // extend the library search path
     println!("cargo:rustc-link-search={}", out_dir.display());
     // copy
-    let linkerscript = match target.unwrap().to_str().unwrap() {
-        "nanos" => "nanos_layout.ld",
-        "nanox" => "nanox_layout.ld",
-        "nanosplus" => "nanosplus_layout.ld",
-        _ => "",
+    let linkerscript = match device {
+        NanoS => "nanos_layout.ld",
+        NanoX => "nanox_layout.ld",
+        NanoSPlus => "nanosplus_layout.ld",
     };
     std::fs::copy(linkerscript, out_dir.join(linkerscript))?;
     std::fs::copy("link.ld", out_dir.join("link.ld"))?;

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,6 @@ use std::process::Command;
 use std::{env, error::Error, fs::File, io::Read};
 
 fn finalize_nanos_configuration(command: &mut cc::Build, bolos_sdk: &String) -> String {
-    println!("cargo:rustc-cfg=nanos");
     command
         .target("thumbv6m-none-eabi")
         .define("ST31", None)
@@ -25,7 +24,6 @@ fn finalize_nanos_configuration(command: &mut cc::Build, bolos_sdk: &String) -> 
 }
 
 fn finalize_nanox_configuration(command: &mut cc::Build, bolos_sdk: &String) -> String {
-    println!("cargo:rustc-cfg=nanox");
     command
         .target("thumbv6m-none-eabi")
         .define("ST33", None)
@@ -86,7 +84,6 @@ fn finalize_nanox_configuration(command: &mut cc::Build, bolos_sdk: &String) -> 
 }
 
 fn finalize_nanosplus_configuration(command: &mut cc::Build, bolos_sdk: &String) -> String {
-    println!("cargo:rustc-cfg=nanosplus");
     command
         .target("thumbv8m.main-none-eabi")
         .define("ST33K1M5", None)

--- a/build.rs
+++ b/build.rs
@@ -200,7 +200,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         ),
     };
 
-    let cx_makefile = match NanoS {
+    let cx_makefile = match device {
         NanoS => finalize_nanos_configuration(&mut command, &bolos_sdk),
         NanoX => finalize_nanox_configuration(&mut command, &bolos_sdk),
         NanoSPlus => finalize_nanosplus_configuration(&mut command, &bolos_sdk),

--- a/nanos.json
+++ b/nanos.json
@@ -20,5 +20,7 @@
   },
   "relocation-model": "ropi",
   "singlethread": true,
-  "target-pointer-width": "32"
+  "target-pointer-width": "32",
+  "os": "nanos",
+  "target-family": [ "bolos" ]
 }

--- a/nanosplus.json
+++ b/nanosplus.json
@@ -19,5 +19,7 @@
   },
   "relocation-model": "ropi-rwpi",
   "singlethread": true,
-  "target-pointer-width": "32"
+  "target-pointer-width": "32",
+  "os": "nanosplus",
+  "target-family": [ "bolos" ]
 }

--- a/nanox.json
+++ b/nanox.json
@@ -19,5 +19,8 @@
   },
   "relocation-model": "ropi-rwpi",
   "singlethread": true,
-  "target-pointer-width": "32"
+  "target-pointer-width": "32",
+  "os": "nanox",
+  "target-family": [ "bolos" ]
+
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,5 +1,5 @@
 use crate::bindings::*;
-#[cfg(nanox)]
+#[cfg(target_os = "nanox")]
 use crate::ble;
 use crate::buttons::{get_button_event, ButtonEvent, ButtonsState};
 
@@ -136,7 +136,7 @@ impl Comm {
                 seph::seph_send(&[seph::SephTags::RawAPDU as u8, len[0], len[1]]);
                 seph::seph_send(&self.apdu_buffer[..self.tx]);
             }
-            #[cfg(nanox)]
+            #[cfg(target_os = "nanox")]
             APDU_BLE => {
                 ble::send(&self.apdu_buffer[..self.tx]);
             }
@@ -266,7 +266,7 @@ impl Comm {
                     seph::handle_capdu_event(&mut self.apdu_buffer, &spi_buffer)
                 }
 
-                #[cfg(nanox)]
+                #[cfg(target_os = "nanox")]
                 seph::Events::BleReceive => ble::receive(&mut self.apdu_buffer, &spi_buffer),
 
                 seph::Events::TickerEvent => return Event::Ticker,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 
 pub mod bindings;
 
-#[cfg(nanox)]
+#[cfg(target_os = "nanox")]
 pub mod ble;
 
 pub mod buttons;

--- a/src/nvm.rs
+++ b/src/nvm.rs
@@ -184,11 +184,11 @@ macro_rules! atomic_storage {
     };
 }
 
-#[cfg(nanos)]
+#[cfg(target_os = "nanos")]
 atomic_storage!(64);
-#[cfg(nanox)]
+#[cfg(target_os = "nanox")]
 atomic_storage!(256);
-#[cfg(nanosplus)]
+#[cfg(target_os = "nanosplus")]
 atomic_storage!(512);
 
 pub enum AtomicStorageElem {

--- a/src/seph.rs
+++ b/src/seph.rs
@@ -3,7 +3,7 @@
 use crate::bindings::*;
 use crate::usbbindings::*;
 
-#[cfg(nanox)]
+#[cfg(target_os = "nanox")]
 use crate::ble;
 
 #[repr(u8)]
@@ -245,7 +245,7 @@ pub fn handle_event(apdu_buffer: &mut [u8], spi_buffer: &[u8]) {
                 handle_usb_ep_xfer_event(apdu_buffer, spi_buffer);
             }
         }
-        #[cfg(nanox)]
+        #[cfg(target_os = "nanox")]
         Events::BleReceive => ble::receive(apdu_buffer, spi_buffer),
         Events::CAPDUEvent => handle_capdu_event(apdu_buffer, spi_buffer),
         Events::TickerEvent => { /* unsafe{ G_io_app.ms += 100; } */ }


### PR DESCRIPTION
The first change is to parse once, and then use an enum for the device. This is hopefully a straightforward improvement.

The second change is to case on the OS name (leveraging https://github.com/LedgerHQ/ledger-nanos-sdk/pull/38) instead of the target name. The target "name" isn't so structured, and it is unclear to what extent it should be anm exposed part of the target. (See https://github.com/rust-lang/rust/pull/98225 for example, where the contents rather than json file path were used as a a key.)

With https://github.com/LedgerHQ/ledger-nanos-sdk/pull/38 the device name is used for the OS field instead, and so we are robust to confusing behavior around names.

depends on #38