### PR TITLE
cleanup target detection so TARGET works as well as CARGO_CFG_TARGET_OS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ cc = "1.0.73"
 testmacro = { git = "https://github.com/yhql/testmacro"} 
 
 [dependencies]
-num-traits = { version = "0.2.14", default-features = false }
-
+num-traits = { version = "0.2.14", default_features = false }
+rand_core = { version = "0.6.3", default_features = false }
 
 [profile.release]
 opt-level = 's' 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,12 @@ version = "0.2.0"
 authors = ["yhql"]
 edition = "2021"
 
+links = "nanos-sdk"
+
 [build-dependencies]
 cc = "1.0.73"
+strum = { version = "0.24.1", features = [ "derive" ] }
+anyhow = "1.0.64"
 
 [dev-dependencies]
 testmacro = { git = "https://github.com/yhql/testmacro"} 

--- a/src/random.rs
+++ b/src/random.rs
@@ -81,7 +81,7 @@ impl Random for u32 {
 }
 
 /// [`RngCore`] implementation via the [`rand_bytes`] syscall
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct LedgerRng;
 
 /// Implement [`RngCore`] (for `rand_core@0.6.x`) using ledger syscalls


### PR DESCRIPTION
extends target detection in build.rs to work for both `TARGET` and `CARGO_CFG_TARGET_OS` to work with `RUST_TARGET_PATH` tricks (broken by a recent PR) and adds a couple of exported variables for downstream use.

blocked on / includes #41 because it's easier for me to stack PRs, can split if required