### PR TITLE
Added exit_app to end tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,8 @@ pub fn sdk_test_runner(tests: &[&TestType]) {
         debug_print(name);
         debug_print("\n");
     }
+
+    exit_app(0);
 }
 
 /// This variant of `assert_eq!()` returns an error


### PR DESCRIPTION
@yhql Fixed `sdk_test_runner` so that after the tests are done, the application will stop