### PR TITLE
Targets fix

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -178,6 +178,18 @@ fn main() -> Result<(), Box<dyn Error>> {
             "{}/lib_stusb/STM32_USB_Device_Library/Class/HID/Src/usbd_hid.c",
             bolos_sdk
         ))
+        .file(format!(
+            "{}/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_cmd.c",
+            bolos_sdk
+        ))
+        .file(format!(
+            "{}/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_core.c",
+            bolos_sdk
+        ))
+        .file(format!(
+            "{}/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_if.c",
+            bolos_sdk
+        ))
         .define("HAVE_LOCAL_APDU_BUFFER", None)
         .define("IO_HID_EP_LENGTH", Some("64"))
         .define("USB_SEGMENT_SIZE", Some("64"))
@@ -185,6 +197,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .define("HAVE_IO_USB", None)
         .define("HAVE_L4_USBLIB", None)
         .define("HAVE_USB_APDU", None)
+        .define("HAVE_USB_CLASS_CCID", None)
+        .define("__IO", Some("volatile"))
         .define("IO_USB_MAX_ENDPOINTS", Some("6"))
         .define("IO_SEPROXYHAL_BUFFER_SIZE_B", Some("128"))
         .include(gcc_toolchain)
@@ -197,6 +211,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         ))
         .include(format!(
             "{}/lib_stusb/STM32_USB_Device_Library/Class/HID/Inc",
+            bolos_sdk
+        ))
+        .include(format!(
+            "{}/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc",
             bolos_sdk
         ))
         .debug(true)

--- a/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/sc_itf.h
+++ b/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/sc_itf.h
@@ -1,0 +1,82 @@
+/**
+  ******************************************************************************
+  * @file    sc_itf.h  
+  * @author  MCD Application Team
+  * @version V1.0.0
+  * @date    31-January-2014
+  * @brief   Evaluation board specific configuration file.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2014 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __SC_ITF_H
+#define __SC_ITF_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_ccid_if.h"
+
+#ifdef HAVE_USB_CLASS_CCID
+
+#include "usbd_ccid_cmd.h"
+
+
+/* Exported macro ------------------------------------------------------------*/
+#define MAX_EXTRA_GUARD_TIME (0xFF - DEFAULT_EXTRA_GUARDTIME)
+
+ /* Following macros are used for SC_XferBlock command */
+#define XFER_BLK_SEND_DATA     1     /* Command is for issuing the data  */
+#define XFER_BLK_RECEIVE_DATA  2     /* Command is for receiving the data */
+#define XFER_BLK_NO_DATA       3     /* Command type is No data exchange  */
+
+/* Exported functions ------------------------------------------------------- */
+/* APPLICATION LAYER ---------------------------------------------------------*/
+#define SC_VOLTAGE_1_8V 1
+#define SC_VOLTAGE_3V 2
+#define SC_VOLTAGE_5V 3
+uint8_t SC_AnswerToReset (uint8_t voltage, uint8_t* atr_buffer);
+//uint8_t SC_GetState (void);
+//void SC_SetState (uint8_t scState);
+uint8_t SC_Detect(void);
+void SC_Poweroff(void);
+void SC_ConfigDetection (void);
+void SC_SaveVoltage (uint8_t );
+void SC_UpdateParams (void);
+void SC_InitParams (void);
+uint8_t SC_SetParams (Protocol0_DataStructure_t* );
+uint8_t SC_ExecuteEscape (uint8_t* escapePtr, uint32_t escapeLen, 
+                          uint8_t* responseBuff,
+                          uint16_t* responseLen);
+uint8_t SC_SetClock (uint8_t bClockCommand);
+uint8_t SC_XferBlock (uint8_t* ptrBlock, uint32_t blockLen, uint16_t* expectedLen);
+uint8_t SC_Request_GetClockFrequencies(uint8_t* pbuf, uint16_t* len);
+uint8_t SC_Request_GetDataRates(uint8_t* pbuf, uint16_t* len);
+uint8_t SC_T0Apdu(uint8_t bmChanges, uint8_t bClassGetResponse, 
+                  uint8_t bClassEnvelope);
+uint8_t SC_Mechanical(uint8_t bFunction);
+uint8_t SC_SetDataRateAndClockFrequency(uint32_t dwClockFrequency, 
+                                        uint32_t dwDataRate); 
+uint8_t SC_Secure(uint32_t dwLength, uint8_t bBWI, uint16_t wLevelParameter, 
+                    uint8_t* pbuf, uint32_t* returnLen );
+
+#endif // HAVE_USB_CLASS_CCID
+
+#endif /* __SC_ITF_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/usbd_ccid_cmd.h
+++ b/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/usbd_ccid_cmd.h
@@ -1,0 +1,194 @@
+/**
+  ******************************************************************************
+  * @file    usbd_ccid_cmd.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    31-January-2014
+  * @brief   CCID Commands handling prototype
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2014 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USBD_CCID_CMD_H
+#define __USBD_CCID_CMD_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_ccid_core.h"
+
+#ifdef HAVE_USB_CLASS_CCID
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported macro ------------------------------------------------------------*/
+
+/******************************************************************************/
+/*  ERROR CODES for USB Bulk In Messages : bError                   */
+/******************************************************************************/
+
+#define   SLOT_NO_ERROR         0x81
+#define   SLOTERROR_UNKNOWN     0x82
+
+/* Index of not supported / incorrect message parameter : 7Fh to 01h */
+/* These Values are used for Return Types between Firmware Layers    */
+/*
+Failure of a command 
+The CCID cannot parse one parameter or the ICC is not supporting one parameter. 
+Then the Slot Error register contains the index of the first bad parameter as a 
+positive number (1-127). For instance, if the CCID receives an ICC command to 
+an unimplemented slot, then the Slot Error register shall be set to 
+‘5’ (index of bSlot field).
+  */
+
+#define   SLOTERROR_BAD_LENTGH                    0x01
+#define   SLOTERROR_BAD_SLOT                      0x05
+#define   SLOTERROR_BAD_POWERSELECT               0x07
+#define   SLOTERROR_BAD_PROTOCOLNUM               0x07
+#define   SLOTERROR_BAD_CLOCKCOMMAND              0x07
+#define   SLOTERROR_BAD_ABRFU_3B                  0x07
+#define   SLOTERROR_BAD_BMCHANGES                 0x07
+#define   SLOTERROR_BAD_BFUNCTION_MECHANICAL      0x07
+#define   SLOTERROR_BAD_ABRFU_2B                  0x08
+#define   SLOTERROR_BAD_LEVELPARAMETER            0x08
+#define   SLOTERROR_BAD_FIDI                      0x0A
+#define   SLOTERROR_BAD_T01CONVCHECKSUM           0x0B
+#define   SLOTERROR_BAD_GUARDTIME                 0x0C
+#define   SLOTERROR_BAD_WAITINGINTEGER            0x0D
+#define   SLOTERROR_BAD_CLOCKSTOP                 0x0E
+#define   SLOTERROR_BAD_IFSC                      0x0F
+#define   SLOTERROR_BAD_NAD                       0x10
+#define   SLOTERROR_BAD_DWLENGTH                  0x08  /* Used in PC_to_RDR_XfrBlock*/
+
+/*----------  Table 6.2-2 Slot error register when bmCommandStatus = 1        */
+#define   SLOTERROR_CMD_ABORTED                    0xFF
+#define   SLOTERROR_ICC_MUTE                       0xFE
+#define   SLOTERROR_XFR_PARITY_ERROR               0xFD
+#define   SLOTERROR_XFR_OVERRUN                    0xFC
+#define   SLOTERROR_HW_ERROR                       0xFB
+#define   SLOTERROR_BAD_ATR_TS                     0xF8
+#define   SLOTERROR_BAD_ATR_TCK                    0xF7
+#define   SLOTERROR_ICC_PROTOCOL_NOT_SUPPORTED     0xF6
+#define   SLOTERROR_ICC_CLASS_NOT_SUPPORTED        0xF5
+#define   SLOTERROR_PROCEDURE_BYTE_CONFLICT        0xF4
+#define   SLOTERROR_DEACTIVATED_PROTOCOL           0xF3
+#define   SLOTERROR_BUSY_WITH_AUTO_SEQUENCE        0xF2
+#define   SLOTERROR_PIN_TIMEOUT                    0xF0
+#define   SLOTERROR_PIN_CANCELLED                  0xEF
+#define   SLOTERROR_CMD_SLOT_BUSY                  0xE0
+#define   SLOTERROR_CMD_NOT_SUPPORTED              0x00
+
+
+#define   DEFAULT_FIDI              0x11 /* DEFAULT_FIDI_VALUE */
+#define   DEFAULT_T01CONVCHECKSUM   0x00
+#define   DEFAULT_EXTRA_GUARDTIME   0x00
+#define   DEFAULT_WAITINGINTEGER    0x0A
+#define   DEFAULT_CLOCKSTOP         0x00
+#define   DEFAULT_IFSC              0x20
+#define   DEFAULT_NAD               0x00
+
+#define   DEFAULT_DATA_RATE    0x000025CD
+#define   DEFAULT_CLOCK_FREQ   0x00000E10
+
+
+/*
+Offset=0 bmICCStatus 2 bit  0, 1, 2
+    0 - An ICC is present and active (power is on and stable, RST is inactive)
+    1 - An ICC is present and inactive (not activated or shut down by hardware error)
+    2 - No ICC is present
+    3 - RFU
+Offset=0 bmRFU 4 bits 0 RFU
+Offset=6 bmCommandStatus 2 bits 0, 1, 2
+    0 - Processed without error
+    1 - Failed (error code provided by the error register)
+    2 - Time Extension is requested
+    3 - RFU
+  */
+
+#define BM_ICC_PRESENT_ACTIVE 0x00
+#define BM_ICC_PRESENT_INACTIVE 0x01
+#define BM_ICC_NO_ICC_PRESENT   0x02
+
+#define BM_COMMAND_STATUS_OFFSET 0x06
+#define BM_COMMAND_STATUS_NO_ERROR 0x00 
+#define BM_COMMAND_STATUS_FAILED   (0x01 << BM_COMMAND_STATUS_OFFSET)
+#define BM_COMMAND_STATUS_TIME_EXTN  (0x02 << BM_COMMAND_STATUS_OFFSET)
+
+/* defines for the CCID_CMD Layers */
+#define SIZE_OF_ATR 33
+#define LEN_RDR_TO_PC_SLOTSTATUS 10
+#define LEN_PROTOCOL_STRUCT_T0   5
+
+#define BPROTOCOL_NUM_T0  0
+#define BPROTOCOL_NUM_T1  1
+
+/************************************************************************************/
+/*   ERROR CODES for RDR_TO_PC_HARDWAREERROR Message : bHardwareErrorCode           */
+/************************************************************************************/
+
+#define   HARDWAREERRORCODE_OVERCURRENT       0x01
+#define   HARDWAREERRORCODE_VOLTAGEERROR      0x02
+#define   HARDWAREERRORCODE_OVERCURRENT_IT    0x04
+#define   HARDWAREERRORCODE_VOLTAGEERROR_IT   0x08
+
+typedef enum 
+{
+  CHK_PARAM_SLOT = 1,
+  CHK_PARAM_DWLENGTH = (1<<1),
+  CHK_PARAM_abRFU2 = (1<<2), 
+  CHK_PARAM_abRFU3 = (1<<3),
+  CHK_PARAM_CARD_PRESENT = (1<<4),
+  CHK_PARAM_ABORT = (1<<5),
+  CHK_ACTIVE_STATE = (1<<6)
+} ChkParam_t;
+
+
+/* Exported functions ------------------------------------------------------- */
+
+uint8_t  PC_to_RDR_IccPowerOn(void);
+uint8_t  PC_to_RDR_IccPowerOff(void);
+uint8_t  PC_to_RDR_GetSlotStatus(void);
+uint8_t  PC_to_RDR_XfrBlock(void);
+uint8_t  PC_to_RDR_GetParameters(void);
+uint8_t  PC_to_RDR_ResetParameters(void);
+uint8_t  PC_to_RDR_SetParameters(void);
+uint8_t  PC_to_RDR_Escape(void);
+uint8_t  PC_to_RDR_IccClock(void);
+uint8_t  PC_to_RDR_Abort(void);
+uint8_t  PC_TO_RDR_T0Apdu(void);
+uint8_t  PC_TO_RDR_Mechanical(void);
+uint8_t  PC_TO_RDR_SetDataRateAndClockFrequency(void);
+uint8_t  PC_TO_RDR_Secure(void);
+
+void RDR_to_PC_DataBlock(unsigned char );
+void RDR_to_PC_NotifySlotChange(void);
+void RDR_to_PC_SlotStatus(unsigned char );
+void RDR_to_PC_Parameters(unsigned char );
+void RDR_to_PC_Escape(unsigned char );
+void RDR_to_PC_DataRateAndClockFrequency(uint8_t  errorCode);
+
+
+void CCID_UpdSlotStatus (uint8_t );
+void CCID_UpdSlotChange (uint8_t );
+uint8_t CCID_IsSlotStatusChange (void);
+uint8_t CCID_CmdAbort(uint8_t slot, uint8_t seq);
+
+#endif // HAVE_USB_CLASS_CCID
+
+#endif /* __USBD_CCID_CMD_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/usbd_ccid_core.h
+++ b/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/usbd_ccid_core.h
@@ -1,0 +1,73 @@
+/**
+  ******************************************************************************
+  * @file    usbd_ccid_core.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    31-January-2014
+  * @brief   This file provides all the CCID core functions.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2014 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef _USB_CCID_CORE_H_
+#define _USB_CCID_CORE_H_
+
+#include "os.h"
+#include "os_io.h"
+#include "os_io_seproxyhal.h"
+
+#ifdef HAVE_USB_CLASS_CCID
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_core.h"
+#include "usbd_ccid_impl.h"
+#include "sc_itf.h"
+
+/* Exported defines ----------------------------------------------------------*/
+
+#define REQUEST_ABORT                  0x01
+#define REQUEST_GET_CLOCK_FREQUENCIES  0x02
+#define REQUEST_GET_DATA_RATES         0x03
+
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported macros -----------------------------------------------------------*/
+/* Exported variables --------------------------------------------------------*/
+/* Exported functions ------------------------------------------------------- */
+uint8_t  USBD_CCID_Init (USBD_HandleTypeDef  *pdev, 
+                            uint8_t cfgidx);
+
+uint8_t  USBD_CCID_DeInit (USBD_HandleTypeDef  *pdev, 
+                              uint8_t cfgidx);
+
+uint8_t  USBD_CCID_Setup (USBD_HandleTypeDef  *pdev, 
+                             USBD_SetupReqTypedef *req);
+
+uint8_t  USBD_CCID_DataIn (USBD_HandleTypeDef  *pdev, 
+                              uint8_t epnum);
+
+uint8_t  USBD_CCID_DataOut (USBD_HandleTypeDef *pdev, 
+                              uint8_t epnum, uint8_t* buffer, apdu_buffer_t * apdu_buffer);
+
+#endif // HAVE_USB_CLASS_CCID
+
+#endif  /* _USB_CCID_CORE_H_ */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/usbd_ccid_if.h
+++ b/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/usbd_ccid_if.h
@@ -1,0 +1,230 @@
+/**
+  ******************************************************************************
+  * @file    usbd_ccid_if.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    31-January-2014
+  * @brief   This file provides all the functions prototypes for USB CCID
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2014 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USBD_CCID_IF_H
+#define __USBD_CCID_IF_H
+
+#include "usbd_core.h"
+
+#ifdef HAVE_USB_CLASS_CCID
+
+
+/* Exported defines ----------------------------------------------------------*/
+/* Bulk-only Command Block Wrapper */
+//#define ABDATA_SIZE 261
+#define CCID_HEADER_SIZE 10
+
+
+#define CCID_INT_BUFF_SIZ 2
+
+#define CARD_SLOT_FITTED  1
+#define CARD_SLOT_REMOVED  0
+
+#define BULK_MAX_PACKET_SIZE 0x40
+#define CCID_IN_EP_SIZE   0x40
+#define INTR_MAX_PACKET_SIZE 8
+#define CCID_MESSAGE_HEADER_SIZE 10
+#define CCID_NUMBER_OF_SLOTS     1       
+                         /* Number of SLOTS. For single card, this value is 1 */
+
+/* Following Parameters used in PC_to_RDR_IccPowerOn */
+#define VOLTAGE_SELECTION_AUTOMATIC  0xFF
+#define VOLTAGE_SELECTION_3V  0x02
+#define VOLTAGE_SELECTION_5V  0x01
+#define VOLTAGE_SELECTION_1V8 0x03
+
+#define		PC_TO_RDR_ICCPOWERON		0x62
+#define		PC_TO_RDR_ICCPOWEROFF		0x63
+#define		PC_TO_RDR_GETSLOTSTATUS		0x65
+#define		PC_TO_RDR_XFRBLOCK	        0x6F
+#define		PC_TO_RDR_GETPARAMETERS		0x6C
+#define		PC_TO_RDR_RESETPARAMETERS	0x6D
+#define		PC_TO_RDR_SETPARAMETERS		0x61
+#define		PC_TO_RDR_ESCAPE		0x6B
+#define		PC_TO_RDR_ICCCLOCK		0x6E
+#define		PC_TO_RDR_T0APDU		0x6A
+#define		PC_TO_RDR_SECURE		0x69
+#define		PC_TO_RDR_MECHANICAL		0x71
+#define		PC_TO_RDR_ABORT			0x72
+#define		PC_TO_RDR_SETDATARATEANDCLOCKFREQUENCY		0x73
+
+#define		RDR_TO_PC_DATABLOCK		0x80
+#define		RDR_TO_PC_SLOTSTATUS		0x81
+#define		RDR_TO_PC_PARAMETERS		0x82
+#define		RDR_TO_PC_ESCAPE		0x83
+#define		RDR_TO_PC_DATARATEANDCLOCKFREQUENCY		0x84
+
+#define		RDR_TO_PC_NOTIFYSLOTCHANGE	0x50
+#define		RDR_TO_PC_HARDWAREERROR		0x51
+
+#define         OFFSET_INT_BMESSAGETYPE  0
+#define         OFFSET_INT_BMSLOTICCSTATE 1
+#define         SLOT_ICC_PRESENT 0x01  
+                /* LSb : (0b = no ICC present, 1b = ICC present) */
+
+#define         SLOT_ICC_CHANGE  0x02  /* MSb : (0b = no change, 1b = change) */
+/*****************************************************************************/
+/*********************** CCID Bulk Transfer State machine ********************/
+/*****************************************************************************/
+#define CCID_STATE_IDLE                      0       /* Idle state */
+#define CCID_STATE_DATA_OUT                  1       /* Data Out state */
+#define CCID_STATE_RECEIVE_DATA              2
+#define CCID_STATE_SEND_RESP                 3
+#define CCID_STATE_DATAIN                    4
+#define CCID_STATE_UNCORRECT_LENGTH          5
+
+#define DIR_IN                        0
+#define DIR_OUT                       1
+#define BOTH_DIR                      2
+
+/* Exported types ------------------------------------------------------------*/
+#pragma pack(1)
+typedef union ccid_bulk_header_u {
+  #pragma pack(1)
+  struct {
+    uint8_t bMessageType; /* Offset = 0*/
+    uint32_t dwLength;    /* Offset = 1, The length field (dwLength) is the length  
+                            of the message not including the 10-byte header.*/
+    uint8_t bSlot;        /* Offset = 5*/
+    uint8_t bSeq;         /* Offset = 6*/
+    uint8_t bSpecific_0;  /* Offset = 7*/
+    uint8_t bSpecific_1;  /* Offset = 8*/
+    uint8_t bSpecific_2;  /* Offset = 9*/
+  } bulkout;
+  #pragma pack(1)
+  struct {
+    uint8_t bMessageType;   /* Offset = 0  Same as Bulk OUT*/
+    uint32_t dwLength;      /* Offset = 1  Same as Bulk OUT*/
+    uint8_t bSlot;          /* Offset = 5, Same as Bulk-OUT message */ 
+    uint8_t bSeq;           /* Offset = 6, Same as Bulk-OUT message */
+    uint8_t bStatus;        /* Offset = 7, Slot status as defined in § 6.2.6*/
+    uint8_t bError;         /* Offset = 8, Slot error  as defined in § 6.2.6*/
+    uint8_t bSpecific;      /* Offset = 9*/
+  } bulkin;
+} ccid_bulk_header_t;
+
+#pragma pack(1)
+typedef struct 
+{ 
+  ccid_bulk_header_t header;
+} Ccid_bulk_data_t; 
+#pragma pack()
+
+
+#pragma pack()
+
+typedef struct 
+{ 
+  __IO uint8_t SlotStatus;
+  __IO uint8_t SlotStatusChange;
+} Ccid_SlotStatus_t; 
+
+
+typedef struct 
+{ 
+  __IO uint8_t bAbortRequestFlag; 
+  __IO uint8_t bSeq; 
+  __IO uint8_t bSlot;
+} usb_ccid_param_t; 
+
+
+#pragma pack(1)
+typedef struct _Protocol0_DataStructure_t
+{
+  uint8_t bmFindexDindex;
+  uint8_t bmTCCKST0;
+  uint8_t bGuardTimeT0;
+  uint8_t bWaitingIntegerT0;
+  uint8_t bClockStop;
+} Protocol0_DataStructure_t;
+#pragma pack()
+
+/* Exported constants --------------------------------------------------------*/
+/* Exported types ------------------------------------------------------------*/
+typedef struct
+{
+  uint8_t voltage;  /* Voltage for the Card Already Selected */
+  uint8_t USART_GuardTime;
+  uint8_t SC_A2R_FiDi;
+  uint8_t SC_hostFiDi;
+  uint8_t USART_DefaultGuardTime;
+  uint32_t USART_BaudRate;
+} SC_Param_t;
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_ccid_core.h"
+
+
+typedef struct usb_class_ccid_s {
+  uint8_t Ccid_BulkState;
+  uint8_t ccid_card_inserted;
+  #ifdef HAVE_CCID_INTERRUPT
+  uint8_t UsbIntMessageBuffer[INTR_MAX_PACKET_SIZE];  /* data buffer*/
+  __IO uint8_t PrevXferComplete_IntrIn;
+  #endif // HAVE_CCID_INTERRUPT
+  usb_ccid_param_t usb_ccid_param;
+
+  uint8_t* pUsbMessageBuffer;
+  uint32_t UsbMessageLength;
+  Ccid_SlotStatus_t Ccid_SlotStatus;
+  Protocol0_DataStructure_t Protocol0_DataStructure;
+  //Ccid_bulk_data_t Ccid_bulk_data;
+  ccid_bulk_header_t bulk_header;
+
+  SC_Param_t SC_Param;
+} usb_class_ccid_t;
+extern usb_class_ccid_t G_io_ccid;
+
+/* Exported macros -----------------------------------------------------------*/
+/* Exported variables --------------------------------------------------------*/
+/* Exported functions ------------------------------------------------------- */ 
+void CCID_BulkMessage_In (USBD_HandleTypeDef  *pdev, 
+                     uint8_t epnum);
+
+void CCID_BulkMessage_Out (USBD_HandleTypeDef  *pdev, 
+                            uint8_t epnum, uint8_t* buffer, uint16_t buflen);
+
+void CCID_ReceiveCmdHeader(uint8_t* pDst, uint8_t u8length);
+void CCID_CmdDecode(USBD_HandleTypeDef  *pdev);
+
+void CCID_IntMessage(USBD_HandleTypeDef  *pdev);
+void CCID_Init(USBD_HandleTypeDef  *pdev);
+void CCID_DeInit(USBD_HandleTypeDef  *pdev);
+
+uint8_t CCID_IsIntrTransferComplete(void);
+void CCID_SetIntrTransferStatus (uint8_t );
+void Transfer_Data_Request(void);
+void Set_CSW (uint8_t CSW_Status, uint8_t Send_Permission);
+
+void io_usb_ccid_set_card_inserted(unsigned int inserted);
+
+#endif // HAVE_USB_CLASS_CCID
+
+#endif /* __USBD_CCID_IF_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_cmd.c
+++ b/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_cmd.c
@@ -1,0 +1,1054 @@
+/**
+  ******************************************************************************
+  * @file    usbd_ccid_cmd.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    31-January-2014
+  * @brief   CCID Commands handling 
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2014 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_ccid_cmd.h"
+#include <string.h>
+
+#ifdef HAVE_USB_CLASS_CCID
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+#define CCID_UpdateCommandStatus(cmd_status,icc_status)\
+ G_io_ccid.bulk_header.bulkin.bStatus=(cmd_status|icc_status)
+  /* 
+  The Above Macro can take any of following Values 
+  #define BM_ICC_PRESENT_ACTIVE 0x00
+  #define BM_ICC_PRESENT_INACTIVE 0x01
+  #define BM_ICC_NO_ICC_PRESENT   0x02
+
+  #define BM_COMMAND_STATUS_OFFSET 0x06
+  #define BM_COMMAND_STATUS_NO_ERROR 0x00 
+  #define BM_COMMAND_STATUS_FAILED   (0x01 << BM_COMMAND_STATUS_OFFSET)
+  #define BM_COMMAND_STATUS_TIME_EXTN  (0x02 << BM_COMMAND_STATUS_OFFSET)
+  */
+
+/* Private function prototypes -----------------------------------------------*/
+static uint8_t CCID_CheckCommandParams (uint32_t param_type);
+
+/* Private functions ---------------------------------------------------------*/
+
+/**
+  * @brief  PC_to_RDR_IccPowerOn
+  *         PC_TO_RDR_ICCPOWERON message execution, apply voltage and get ATR	
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t PC_to_RDR_IccPowerOn(void)
+{
+  /* Apply the ICC VCC
+     Fills the Response buffer with ICC ATR 
+     This Command is returned with RDR_to_PC_DataBlock(); 
+  */
+  
+  uint8_t voltage;
+  uint8_t sc_voltage = 0;
+  uint8_t error;
+  
+  G_io_ccid.bulk_header.bulkin.dwLength = 0;  /* Reset Number of Bytes in abData */
+  
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_DWLENGTH | \
+                                  CHK_PARAM_abRFU2 |\
+                                  CHK_PARAM_CARD_PRESENT |\
+                                  CHK_PARAM_ABORT );
+  if (error != 0) 
+  {
+    return error;
+  }
+  
+  /* Voltage that is applied to the ICC
+  00h � Automatic Voltage Selection
+  01h � 5.0 volts
+  02h � 3.0 volts
+  03h � 1.8 volts
+  */
+  /* G_io_ccid.bulk_header.bulkout.bSpecific_0 Contains bPowerSelect */
+  voltage = G_io_ccid.bulk_header.bulkout.bSpecific_0;
+  if (voltage >= VOLTAGE_SELECTION_1V8)
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+    return SLOTERROR_BAD_POWERSELECT; /* The Voltage specified is out of Spec */
+  }
+  
+  /* Correct Voltage Requested by the Host */
+  if ((voltage == VOLTAGE_SELECTION_AUTOMATIC) || 
+      (voltage == VOLTAGE_SELECTION_3V))
+  {
+    /* voltage == 00 Voltage Automatic 
+    voltage == 01 Voltage Automatic = 5.0V
+    voltage == 02 Voltage Automatic = 3V
+    voltage == 03 Voltage Automatic = 1.8V
+    */
+    sc_voltage = SC_VOLTAGE_3V;
+  }
+  else if (voltage == VOLTAGE_SELECTION_5V)
+  {
+    sc_voltage = SC_VOLTAGE_5V;
+  }
+  
+  G_io_ccid.bulk_header.bulkin.dwLength = SC_AnswerToReset(sc_voltage, G_io_ccid_data_buffer);
+  
+  /* Check if the Card has come to Active State*/
+  error = CCID_CheckCommandParams(CHK_ACTIVE_STATE);
+  if (error != 0)
+  {
+    /* Check if Voltage is not Automatic */ 
+    if (voltage != 0)
+    { /* If Specific Voltage requested by Host i.e 3V or 5V*/
+      return error;
+    }
+    else
+    {/* Automatic Voltage selection requested by Host */
+      
+      if (sc_voltage != SC_VOLTAGE_5V)
+      { /* If voltage selected was Automatic and 5V is not yet tried */
+        sc_voltage = SC_VOLTAGE_5V;
+        G_io_ccid.bulk_header.bulkin.dwLength = SC_AnswerToReset(sc_voltage, G_io_ccid_data_buffer);
+  
+        /* Check again the State */      
+        error = CCID_CheckCommandParams(CHK_ACTIVE_STATE);
+        if (error != 0) 
+         return error;
+
+      }
+      else 
+      { /* Voltage requested from Host was 5V already*/
+        CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_INACTIVE);
+        return error;
+      }
+    } /* Voltage Selection was automatic */
+  } /* If Active State */  
+  
+  /* ATR is received, No Error Condition Found */
+  CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR, BM_ICC_PRESENT_ACTIVE);
+  
+  return SLOT_NO_ERROR;
+}
+
+/**
+  * @brief  PC_to_RDR_IccPowerOff
+  *         Icc VCC is switched Off 
+  * @param  None 
+  * @retval uint8_t error: status of the command execution 
+  */
+uint8_t PC_to_RDR_IccPowerOff(void)
+{
+  /*  The response to this command message is the RDR_to_PC_SlotStatus 
+  response message. */
+  uint8_t error;
+  
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_abRFU3 |\
+                                  CHK_PARAM_DWLENGTH );
+  if (error != 0) 
+  {
+    return error;
+  }
+  
+  /* Command is ok, Check for Card Presence */ 
+  if (SC_Detect())
+  { 
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR,BM_ICC_PRESENT_INACTIVE);
+  }
+  else
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR,BM_ICC_NO_ICC_PRESENT);
+  }
+  
+  /* Power OFF the card */
+  SC_Poweroff();
+  
+  return SLOT_NO_ERROR;
+}
+
+/**
+  * @brief  PC_to_RDR_GetSlotStatus
+  *         Provides the Slot status to the host 
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t  PC_to_RDR_GetSlotStatus(void)
+{
+    uint8_t error;
+
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_DWLENGTH |\
+                                  CHK_PARAM_CARD_PRESENT |\
+                                  CHK_PARAM_abRFU3 );
+  if (error != 0) 
+  {
+    return error;
+  }
+  
+  CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR,BM_ICC_PRESENT_ACTIVE);
+  return SLOT_NO_ERROR;
+}
+
+
+/**
+  * @brief  PC_to_RDR_XfrBlock
+  *         Handles the Block transfer from Host. 
+  *         Response to this command message is the RDR_to_PC_DataBlock 
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t  PC_to_RDR_XfrBlock(void)
+{
+  uint16_t expectedLength, reqlen;
+  
+      uint8_t error;
+
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_CARD_PRESENT |\
+                                  CHK_PARAM_abRFU3 |\
+                                  CHK_PARAM_ABORT |\
+                                  CHK_ACTIVE_STATE );
+  if (error != 0) 
+    return error;
+    
+  if (G_io_ccid.bulk_header.bulkout.dwLength > IO_CCID_DATA_BUFFER_SIZE)
+  { /* Check amount of Data Sent by Host is > than memory allocated ? */
+    
+    return SLOTERROR_BAD_DWLENGTH;
+  }
+
+
+  /* wLevelParameter = Size of expected data to be returned by the 
+                        bulk-IN endpoint */
+  expectedLength = (G_io_ccid.bulk_header.bulkout.bSpecific_2 << 8) | 
+                    G_io_ccid.bulk_header.bulkout.bSpecific_1;   
+
+  reqlen = G_io_ccid.bulk_header.bulkout.dwLength;
+  
+  G_io_ccid.bulk_header.bulkin.dwLength = (uint16_t)expectedLength;  
+
+
+  error = SC_XferBlock(&G_io_ccid_data_buffer[0], 
+                    reqlen, 
+                    &expectedLength); 
+
+  if (error != SLOT_NO_ERROR)
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+  }
+  else
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR, BM_ICC_PRESENT_ACTIVE);
+    error = SLOT_NO_ERROR;
+  }
+  
+  return error;
+}
+
+
+/**
+  * @brief  PC_to_RDR_GetParameters
+  *         Provides the ICC parameters to the host 
+  *         Response to this command message is the RDR_to_PC_Parameters
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t  PC_to_RDR_GetParameters(void)
+{
+  uint8_t error;
+
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_DWLENGTH |\
+                                  CHK_PARAM_CARD_PRESENT |\
+                                  CHK_PARAM_abRFU3 );
+  if (error != 0) 
+    return error;
+      
+  CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR, BM_ICC_PRESENT_ACTIVE);
+
+  return SLOT_NO_ERROR;
+}
+
+
+/**
+  * @brief  PC_to_RDR_ResetParameters
+  *         Set the ICC parameters to the default 
+  *         Response to this command message is the RDR_to_PC_Parameters
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t  PC_to_RDR_ResetParameters(void)
+{
+  uint8_t error;
+  
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_DWLENGTH |\
+                                  CHK_PARAM_CARD_PRESENT |\
+                                  CHK_PARAM_abRFU3 |\
+                                  CHK_ACTIVE_STATE);
+  if (error != 0) 
+    return error;
+  
+  /* This command resets the slot parameters to their default values */
+  G_io_ccid.Protocol0_DataStructure.bmFindexDindex = DEFAULT_FIDI;
+  G_io_ccid.Protocol0_DataStructure.bmTCCKST0 = DEFAULT_T01CONVCHECKSUM;
+  G_io_ccid.Protocol0_DataStructure.bGuardTimeT0 = DEFAULT_EXTRA_GUARDTIME;
+  G_io_ccid.Protocol0_DataStructure.bWaitingIntegerT0 = DEFAULT_WAITINGINTEGER;
+  G_io_ccid.Protocol0_DataStructure.bClockStop = DEFAULT_CLOCKSTOP;
+  
+  error = SC_SetParams(&G_io_ccid.Protocol0_DataStructure);
+  
+   if (error != SLOT_NO_ERROR)
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+  }
+  else
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR, BM_ICC_PRESENT_ACTIVE);
+    error = SLOT_NO_ERROR;
+  }
+  
+  return error;
+}
+
+
+/**
+  * @brief  PC_to_RDR_SetParameters
+  *         Set the ICC parameters to the host defined parameters
+  *         Response to this command message is the RDR_to_PC_Parameters
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t  PC_to_RDR_SetParameters(void)
+{
+  uint8_t error;
+  
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_CARD_PRESENT |\
+                                  CHK_PARAM_abRFU2 |\
+                                  CHK_ACTIVE_STATE);
+  if (error != 0) 
+    return error;
+  
+  error = SLOT_NO_ERROR;
+  
+  /* for Protocol T=0 (bProtocolNum=0) (dwLength=00000005h) */
+  if ( (G_io_ccid.bulk_header.bulkout.dwLength == 5) &&
+      (G_io_ccid.bulk_header.bulkout.bSpecific_0 != 0))
+    error = SLOTERROR_BAD_PROTOCOLNUM;
+  
+  /* for Protocol T=1 (bProtocolNum=1) (dwLength=00000007h) */
+  if ( (G_io_ccid.bulk_header.bulkout.dwLength == 7) &&
+      (G_io_ccid.bulk_header.bulkout.bSpecific_0 != 1))
+    error = SLOTERROR_CMD_NOT_SUPPORTED;
+    
+  /* For T0, Waiting Integer 0 supported */
+  if (G_io_ccid_data_buffer[3] != 0)
+    error = SLOTERROR_BAD_WAITINGINTEGER;
+      
+  if (G_io_ccid_data_buffer[4] != DEFAULT_CLOCKSTOP)
+     error = SLOTERROR_BAD_CLOCKSTOP;
+   
+  if (error != SLOT_NO_ERROR)
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+  } 
+  
+  memcpy(&G_io_ccid.Protocol0_DataStructure, (Protocol0_DataStructure_t*)(&(G_io_ccid_data_buffer[0])), sizeof(Protocol0_DataStructure_t));
+  error = SC_SetParams(&G_io_ccid.Protocol0_DataStructure);
+  
+   if (error != SLOT_NO_ERROR)
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+  }
+  else
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR, BM_ICC_PRESENT_ACTIVE);
+    error = SLOT_NO_ERROR;
+  }
+  
+  return error;
+}
+
+
+/**
+  * @brief  PC_to_RDR_Escape
+  *         Execute the Escape command. This is user specific Implementation
+  *         Response to this command message is the RDR_to_PC_Escape
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t  PC_to_RDR_Escape(void)
+{
+  uint8_t error;
+  uint16_t size;
+  
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_CARD_PRESENT |\
+                                  CHK_PARAM_abRFU3 |\
+                                  CHK_PARAM_ABORT |\
+                                  CHK_ACTIVE_STATE);
+  
+  if (error != 0) 
+    return error;
+  
+  error = SC_ExecuteEscape(&G_io_ccid_data_buffer[0],
+                           G_io_ccid.bulk_header.bulkout.dwLength,
+                           &G_io_ccid_data_buffer[0],
+                           &size);
+  
+  G_io_ccid.bulk_header.bulkin.dwLength = size;
+  
+  if (error != SLOT_NO_ERROR)
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+  }
+  else
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR, BM_ICC_PRESENT_ACTIVE);
+  }
+  
+  return error;
+}
+
+
+/**
+  * @brief  PC_to_RDR_IccClock
+  *         Execute the Clock specific command from host 
+  *         Response to this command message is the RDR_to_PC_SlotStatus
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t  PC_to_RDR_IccClock(void)
+{
+  uint8_t error;
+  
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_CARD_PRESENT |\
+                                  CHK_PARAM_abRFU2 |\
+                                  CHK_PARAM_DWLENGTH|\
+                                  CHK_ACTIVE_STATE);
+  if (error != 0) 
+    return error;
+
+  /* bClockCommand � 00h restarts Clock
+                   � 01h Stops Clock in the state shown in the bClockStop 
+                       field of the PC_to_RDR_SetParameters command 
+                       and RDR_to_PC_Parameters message.*/
+  if (G_io_ccid.bulk_header.bulkout.bSpecific_0 > 1)
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+    return SLOTERROR_BAD_CLOCKCOMMAND;
+  }
+  
+  error = SC_SetClock(G_io_ccid.bulk_header.bulkout.bSpecific_0);
+  
+  if (error != SLOT_NO_ERROR)
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+  }
+  else
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR, BM_ICC_PRESENT_ACTIVE);
+  }
+  
+  return error;
+}
+
+
+/**
+  * @brief  PC_to_RDR_Abort
+  *         Execute the Abort command from host, This stops all Bulk transfers 
+  *         from host and ICC
+  *         Response to this command message is the RDR_to_PC_SlotStatus
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t  PC_to_RDR_Abort(void)
+{
+    uint8_t error;
+  
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_abRFU3 |\
+                                  CHK_PARAM_DWLENGTH);
+  if (error != 0) 
+    return error;
+  
+  CCID_CmdAbort (G_io_ccid.bulk_header.bulkout.bSlot, G_io_ccid.bulk_header.bulkout.bSeq);
+  CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR,BM_ICC_PRESENT_ACTIVE);               
+  return SLOT_NO_ERROR;
+}
+
+/**
+  * @brief  CCID_CmdAbort
+  *         Execute the Abort command from Bulk EP or from Control EP,
+  *          This stops all Bulk transfers from host and ICC
+  * @param  uint8_t slot: slot number that host wants to abort
+  * @param  uint8_t seq : Seq number for PC_to_RDR_Abort
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t CCID_CmdAbort(uint8_t slot, uint8_t seq)
+{
+   /* This function is called for REQUEST_ABORT & PC_to_RDR_Abort */
+  
+   if (slot >= CCID_NUMBER_OF_SLOTS)
+   { /* This error condition is possible only from CLASS_REQUEST, otherwise
+     Slot is already checked in parameters from PC_to_RDR_Abort request */
+     /* Slot requested is more than supported by Firmware */
+      CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED,BM_ICC_NO_ICC_PRESENT);
+      return SLOTERROR_BAD_SLOT;
+   }
+    
+  if ( G_io_ccid.usb_ccid_param.bAbortRequestFlag == 1)
+  { /* Abort Command was already received from ClassReq or PC_to_RDR */
+    if (( G_io_ccid.usb_ccid_param.bSeq == seq) && (G_io_ccid.usb_ccid_param.bSlot == slot))
+    {
+      /* CLASS Specific request is already Received, Reset the abort flag */
+      G_io_ccid.usb_ccid_param.bAbortRequestFlag = 0;
+    }
+  }
+  else
+  {
+    /* Abort Command was NOT received from ClassReq or PC_to_RDR, 
+       so save them for next ABORT command to verify */
+    G_io_ccid.usb_ccid_param.bAbortRequestFlag = 1;
+    G_io_ccid.usb_ccid_param.bSeq = seq ;
+    G_io_ccid.usb_ccid_param.bSlot = slot;
+  }
+  
+  return 0;
+}
+
+/**
+  * @brief  PC_TO_RDR_T0Apdu
+  *         Execute the PC_TO_RDR_T0APDU command from host
+  *         Response to this command message is the RDR_to_PC_SlotStatus
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t  PC_TO_RDR_T0Apdu(void)
+{
+  uint8_t error;
+  
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_CARD_PRESENT |\
+                                  CHK_PARAM_DWLENGTH |
+                                  CHK_PARAM_ABORT );
+  if (error != 0) 
+    return error;
+  
+  if (G_io_ccid.bulk_header.bulkout.bSpecific_0 > 0x03)
+  {/* Bit 0 is associated with field bClassGetResponse
+      Bit 1 is associated with field bClassEnvelope
+      Other bits are RFU.*/
+    
+   CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE); 
+   return SLOTERROR_BAD_BMCHANGES;
+  }
+  
+  error = SC_T0Apdu(G_io_ccid.bulk_header.bulkout.bSpecific_0, 
+                    G_io_ccid.bulk_header.bulkout.bSpecific_1, 
+                    G_io_ccid.bulk_header.bulkout.bSpecific_2);
+  
+   if (error != SLOT_NO_ERROR)
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+  }
+  else
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR, BM_ICC_PRESENT_ACTIVE);
+  }
+  
+  return error;
+}
+
+/**
+  * @brief  PC_TO_RDR_Mechanical
+  *         Execute the PC_TO_RDR_MECHANICAL command from host
+  *         Response to this command message is the RDR_to_PC_SlotStatus
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t  PC_TO_RDR_Mechanical(void)
+{
+  uint8_t error;
+  
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_CARD_PRESENT |\
+                                  CHK_PARAM_abRFU2 |\
+                                  CHK_PARAM_DWLENGTH 
+                                   );
+  if (error != 0) 
+    return error;
+  
+  if (G_io_ccid.bulk_header.bulkout.bSpecific_0 > 0x05)
+  {/* 01h � Accept Card
+      02h � Eject Card
+      03h � Capture Card
+      04h � Lock Card
+      05h � Unlock Card*/
+    
+   CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE); 
+   return SLOTERROR_BAD_BFUNCTION_MECHANICAL;
+  }
+  
+  error = SC_Mechanical(G_io_ccid.bulk_header.bulkout.bSpecific_0);
+  
+   if (error != SLOT_NO_ERROR)
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+  }
+  else
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR, BM_ICC_PRESENT_ACTIVE);
+  }
+  
+  return error;
+}
+
+/**
+  * @brief  PC_TO_RDR_SetDataRateAndClockFrequency
+  *         Set the required Card Frequency and Data rate from the host. 
+  *         Response to this command message is the 
+  *           RDR_to_PC_DataRateAndClockFrequency
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t  PC_TO_RDR_SetDataRateAndClockFrequency(void)
+{
+  uint8_t error;
+  uint32_t clockFrequency;
+  uint32_t dataRate;
+  
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+    CHK_PARAM_CARD_PRESENT |\
+      CHK_PARAM_abRFU3);
+  if (error != 0) 
+    return error;
+  
+  if (G_io_ccid.bulk_header.bulkout.dwLength != 0x08)
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED,BM_ICC_PRESENT_ACTIVE);
+    return SLOTERROR_BAD_LENTGH;
+  } 
+  
+  /* HERE we avoiding to an unaligned memory access*/ 
+  clockFrequency = U4LE(G_io_ccid_data_buffer, 0);
+  dataRate = U4LE(G_io_ccid_data_buffer, 4);
+  
+  error = SC_SetDataRateAndClockFrequency(clockFrequency, dataRate);
+  G_io_ccid.bulk_header.bulkin.bError = error;
+  
+  if (error != SLOT_NO_ERROR)
+  {
+    G_io_ccid.bulk_header.bulkin.dwLength = 0;
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+  }
+  else
+  {
+    G_io_ccid.bulk_header.bulkin.dwLength = 8;
+    
+    (G_io_ccid_data_buffer[0])  = clockFrequency & 0x000000FF ;
+    (G_io_ccid_data_buffer[1])  =  (clockFrequency & 0x0000FF00) >> 8;
+    (G_io_ccid_data_buffer[2])  =  (clockFrequency & 0x00FF0000) >> 16;
+    (G_io_ccid_data_buffer[3])  =  (clockFrequency & 0xFF000000) >> 24;
+    (G_io_ccid_data_buffer[4])  =  dataRate & 0x000000FF ;
+    (G_io_ccid_data_buffer[5])  =  (dataRate & 0x0000FF00) >> 8;
+    (G_io_ccid_data_buffer[6])  =  (dataRate & 0x00FF0000) >> 16;
+    (G_io_ccid_data_buffer[7])  =  (dataRate & 0xFF000000) >> 24;
+    
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR, BM_ICC_PRESENT_ACTIVE);
+  }
+  
+  return error;
+}
+
+/**
+  * @brief  PC_TO_RDR_Secure
+  *         Execute the Secure Command from the host. 
+  *         Response to this command message is the RDR_to_PC_DataBlock
+  * @param  None 
+  * @retval uint8_t status of the command execution 
+  */
+uint8_t  PC_TO_RDR_Secure(void)
+{
+  uint8_t error;
+  uint8_t bBWI;
+  uint16_t wLevelParameter;
+  uint32_t responseLen; 
+  
+  
+  error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
+                                  CHK_PARAM_CARD_PRESENT |\
+                                  CHK_PARAM_ABORT );
+  
+  if (error != 0) {
+    G_io_ccid.bulk_header.bulkin.dwLength = 0;
+    return error;
+  }
+  
+  bBWI = G_io_ccid.bulk_header.bulkout.bSpecific_0;
+  wLevelParameter = (G_io_ccid.bulk_header.bulkout.bSpecific_1 + ((uint16_t)G_io_ccid.bulk_header.bulkout.bSpecific_2<<8));
+  
+  if ((EXCHANGE_LEVEL_FEATURE == TPDU_EXCHANGE) || 
+    (EXCHANGE_LEVEL_FEATURE == SHORT_APDU_EXCHANGE))
+  {
+    /* TPDU level & short APDU level, wLevelParameter is RFU, = 0000h */
+    if (wLevelParameter != 0 )
+    {
+      G_io_ccid.bulk_header.bulkin.dwLength = 0;
+      CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+      error = SLOTERROR_BAD_LEVELPARAMETER;
+      return error;
+    }
+  }
+
+  error = SC_Secure(G_io_ccid.bulk_header.bulkout.dwLength - CCID_HEADER_SIZE, bBWI, wLevelParameter, 
+                    &G_io_ccid_data_buffer[0], &responseLen);
+
+  G_io_ccid.bulk_header.bulkin.dwLength = responseLen;
+  
+  if (error != SLOT_NO_ERROR)
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
+  }
+  else
+  {
+    CCID_UpdateCommandStatus(BM_COMMAND_STATUS_NO_ERROR, BM_ICC_PRESENT_ACTIVE);
+  }
+  
+  return error;
+}
+
+/******************************************************************************/
+/*		BULK IN ROUTINES															*/
+/******************************************************************************/
+
+/**
+  * @brief  RDR_to_PC_DataBlock
+  *         Provide the data block response to the host 
+  *         Response for PC_to_RDR_IccPowerOn, PC_to_RDR_XfrBlock 
+  * @param  uint8_t errorCode: code to be returned to the host
+  * @retval None 
+  */
+void RDR_to_PC_DataBlock(uint8_t  errorCode)
+{  
+  G_io_ccid.bulk_header.bulkin.bMessageType = RDR_TO_PC_DATABLOCK; 
+  G_io_ccid.bulk_header.bulkin.bError = errorCode; 
+  G_io_ccid.bulk_header.bulkin.bSpecific=0;    /* bChainParameter */
+  
+  /* void the Length Specified in Command */
+  if(errorCode != SLOT_NO_ERROR)
+  {
+    G_io_ccid.bulk_header.bulkin.dwLength = 0;
+  }
+  
+  Transfer_Data_Request();
+
+}
+
+
+/**
+  * @brief  RDR_to_PC_SlotStatus
+  *         Provide the Slot status response to the host 
+  *          Response for PC_to_RDR_IccPowerOff 
+  *                PC_to_RDR_GetSlotStatus
+  *                PC_to_RDR_IccClock
+  *                PC_to_RDR_T0APDU
+  *                PC_to_RDR_Mechanical
+  *         Also the device sends this response message when it has completed 
+  *         aborting a slot after receiving both the Class Specific ABORT request 
+  *          and PC_to_RDR_Abort command message.
+  * @param  uint8_t errorCode: code to be returned to the host
+  * @retval None 
+  */
+void RDR_to_PC_SlotStatus(uint8_t  errorCode)
+{
+  
+  G_io_ccid.bulk_header.bulkin.bMessageType = RDR_TO_PC_SLOTSTATUS; 
+  G_io_ccid.bulk_header.bulkin.dwLength =0;
+  G_io_ccid.bulk_header.bulkin.bError = errorCode; 
+  G_io_ccid.bulk_header.bulkin.bSpecific=0;    /* bClockStatus = 00h Clock running
+                                      01h Clock stopped in state L
+                                      02h Clock stopped in state H
+                                      03h Clock stopped in an unknown state
+                                      All other values are RFU. */                                                                            
+
+  Transfer_Data_Request();
+
+}
+
+/**
+  * @brief  RDR_to_PC_Parameters
+  *         Provide the data block response to the host 
+  *         Response for PC_to_RDR_GetParameters, PC_to_RDR_ResetParameters
+  *                      PC_to_RDR_SetParameters
+  * @param  uint8_t errorCode: code to be returned to the host
+  * @retval None 
+  */
+void RDR_to_PC_Parameters(uint8_t  errorCode)
+{
+  
+  G_io_ccid.bulk_header.bulkin.bMessageType = RDR_TO_PC_PARAMETERS; 
+  G_io_ccid.bulk_header.bulkin.bError = errorCode; 
+  
+  if(errorCode == SLOT_NO_ERROR)
+  { 
+   G_io_ccid.bulk_header.bulkin.dwLength = LEN_PROTOCOL_STRUCT_T0;
+  }
+  else
+  {
+   G_io_ccid.bulk_header.bulkin.dwLength = 0;
+  }
+    
+  memcpy(G_io_ccid_data_buffer, &G_io_ccid.Protocol0_DataStructure, sizeof(G_io_ccid.Protocol0_DataStructure));
+  
+  /* bProtocolNum */
+  G_io_ccid.bulk_header.bulkin.bSpecific = BPROTOCOL_NUM_T0; 
+  
+  Transfer_Data_Request();
+}
+
+/**
+  * @brief  RDR_to_PC_Escape
+  *         Provide the Escaped data block response to the host 
+  *         Response for PC_to_RDR_Escape
+  * @param  uint8_t errorCode: code to be returned to the host
+  * @retval None 
+  */
+void RDR_to_PC_Escape(uint8_t  errorCode)
+{ 
+  G_io_ccid.bulk_header.bulkin.bMessageType = RDR_TO_PC_ESCAPE; 
+  
+  G_io_ccid.bulk_header.bulkin.bSpecific=0;    /* Reserved for Future Use */
+  G_io_ccid.bulk_header.bulkin.bError = errorCode; 
+  
+  /* void the Length Specified in Command */
+  if(errorCode != SLOT_NO_ERROR)
+  {
+    G_io_ccid.bulk_header.bulkin.dwLength = 0;
+  }  
+  
+  Transfer_Data_Request();
+}
+
+
+
+/**
+  * @brief  RDR_to_PC_DataRateAndClockFrequency
+  *         Provide the Clock and Data Rate information to host 
+  *         Response for PC_TO_RDR_SetDataRateAndClockFrequency
+  * @param  uint8_t errorCode: code to be returned to the host
+  * @retval None 
+  */
+void RDR_to_PC_DataRateAndClockFrequency(uint8_t  errorCode)
+{
+  /*
+  uint16_t length = CCID_RESPONSE_HEADER_SIZE;
+  */
+  
+  G_io_ccid.bulk_header.bulkin.bMessageType = RDR_TO_PC_DATARATEANDCLOCKFREQUENCY; 
+  G_io_ccid.bulk_header.bulkin.bError = errorCode; 
+  G_io_ccid.bulk_header.bulkin.bSpecific=0;    /* Reserved for Future Use */
+  
+  /* void the Length Specified in Command */
+  if(errorCode != SLOT_NO_ERROR)
+  {
+    G_io_ccid.bulk_header.bulkin.dwLength = 0;
+  }  
+  
+  Transfer_Data_Request();
+}
+
+#ifdef HAVE_CCID_INTERRUPT
+/**
+  * @brief  RDR_to_PC_NotifySlotChange
+  *         Interrupt message to be sent to the host, Checks the card presence 
+  *           status and update the buffer accordingly
+  * @param  None 
+  * @retval None
+  */
+void RDR_to_PC_NotifySlotChange(void)
+{
+  G_io_ccid.UsbIntMessageBuffer[OFFSET_INT_BMESSAGETYPE] = RDR_TO_PC_NOTIFYSLOTCHANGE;
+  
+  if (SC_Detect() )
+  {	
+    /* 
+    SLOT_ICC_PRESENT 0x01 : LSb : (0b = no ICC present, 1b = ICC present)
+    SLOT_ICC_CHANGE 0x02 : MSb : (0b = no change, 1b = change).
+    */
+    G_io_ccid.UsbIntMessageBuffer[OFFSET_INT_BMSLOTICCSTATE] = SLOT_ICC_PRESENT | 
+                                                     SLOT_ICC_CHANGE;	
+  }
+  else
+  {	
+    G_io_ccid.UsbIntMessageBuffer[OFFSET_INT_BMSLOTICCSTATE] = SLOT_ICC_CHANGE;
+    
+    /* Power OFF the card */
+    SC_Poweroff();
+  }
+}
+#endif // HAVE_CCID_INTERRUPT
+
+
+/**
+  * @brief  CCID_UpdSlotStatus
+  *         Updates the variable for the slot status 
+  * @param  uint8_t slotStatus : slot status from the calling function 
+  * @retval None
+  */
+void CCID_UpdSlotStatus (uint8_t slotStatus)
+{
+   G_io_ccid.Ccid_SlotStatus.SlotStatus = slotStatus;
+}
+
+/**
+  * @brief  CCID_UpdSlotChange
+  *         Updates the variable for the slot change status 
+  * @param  uint8_t changeStatus : slot change status from the calling function 
+  * @retval None
+  */
+void CCID_UpdSlotChange (uint8_t changeStatus)
+{
+   G_io_ccid.Ccid_SlotStatus.SlotStatusChange  = changeStatus;
+}
+
+/**
+  * @brief  CCID_IsSlotStatusChange
+  *         Provides the value of the variable for the slot change status 
+  * @param  None
+  * @retval uint8_t slot change status 
+  */
+uint8_t CCID_IsSlotStatusChange (void)
+{
+  return G_io_ccid.Ccid_SlotStatus.SlotStatusChange;
+}
+
+/**
+  * @brief  CCID_CheckCommandParams
+  *         Checks the specific parameters requested by the function and update 
+  *          status accordingly. This function is called from all 
+  *          PC_to_RDR functions
+  * @param  uint32_t param_type : Parameter enum to be checked by calling function
+  * @retval uint8_t status 
+  */
+static uint8_t CCID_CheckCommandParams (uint32_t param_type)
+{
+  uint32_t parameter;
+  
+  G_io_ccid.bulk_header.bulkin.bStatus = BM_ICC_PRESENT_ACTIVE | BM_COMMAND_STATUS_NO_ERROR ;
+  
+  parameter = (uint32_t)param_type;
+  
+  if (parameter & CHK_PARAM_SLOT)
+  {
+    /* 
+    The slot number (bSlot) identifies which ICC slot is being addressed 
+    by the message, if the CCID supports multiple slots. 
+    The slot number is zero-relative, and is in the range of zero to FFh.
+    */
+    
+    /* SLOT Number is 0 onwards, so always < CCID_NUMBER_OF_SLOTs */
+    /* Error Condition !!! */
+    if (G_io_ccid.bulk_header.bulkout.bSlot >= CCID_NUMBER_OF_SLOTS)
+    { /* Slot requested is more than supported by Firmware */
+      CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED,BM_ICC_NO_ICC_PRESENT);
+      return SLOTERROR_BAD_SLOT;
+    }
+  }
+  
+    if (parameter & CHK_PARAM_CARD_PRESENT)
+  {
+    /* Commands Parameters ok, Check the Card Status */  
+    if (SC_Detect() == 0)
+    { /* Card is Not detected */
+      CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED,BM_ICC_NO_ICC_PRESENT);
+      return SLOTERROR_ICC_MUTE;
+    }
+  }
+  
+  /* Check that DwLength is 0 */
+  if (parameter & CHK_PARAM_DWLENGTH)
+  {
+    if (G_io_ccid.bulk_header.bulkout.dwLength != 0)
+    {
+      CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED,BM_ICC_PRESENT_ACTIVE);
+      return SLOTERROR_BAD_LENTGH;
+    } 
+  }
+  
+  /* abRFU 2 : Reserved for Future Use*/
+  if (parameter & CHK_PARAM_abRFU2)
+  {
+    
+    if ((G_io_ccid.bulk_header.bulkout.bSpecific_1 != 0) ||
+        (G_io_ccid.bulk_header.bulkout.bSpecific_2 != 0))
+    {
+      CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED,BM_ICC_PRESENT_ACTIVE);
+      return SLOTERROR_BAD_ABRFU_2B;        /* bSpecific_1 */
+    }
+  }
+  
+  if (parameter & CHK_PARAM_abRFU3)
+  {
+   /* abRFU 3 : Reserved for Future Use*/
+    if ((G_io_ccid.bulk_header.bulkout.bSpecific_0 != 0) || 
+       (G_io_ccid.bulk_header.bulkout.bSpecific_1 != 0) ||
+       (G_io_ccid.bulk_header.bulkout.bSpecific_2 != 0))
+    {
+       CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED,BM_ICC_PRESENT_ACTIVE);    
+        return SLOTERROR_BAD_ABRFU_3B;    
+    }
+  }
+  
+ 
+  if (parameter & CHK_PARAM_ABORT)
+  {
+    if( G_io_ccid.usb_ccid_param.bAbortRequestFlag )
+    {
+       CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED,BM_ICC_PRESENT_INACTIVE);    
+      return SLOTERROR_CMD_ABORTED; 
+    }
+  }
+  
+  if (parameter & CHK_ACTIVE_STATE)
+  {
+     /* Commands Parameters ok, Check the Card Status */  
+     /* Card is detected */
+    if (! SC_Detect())
+    {
+      /* Check that from Lower Layers, the SmartCard come to known state */
+      CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED,BM_ICC_PRESENT_INACTIVE);
+      return SLOTERROR_HW_ERROR;
+    }    
+  }
+  
+  return 0; 
+}
+
+#endif // HAVE_USB_CLASS_CCID
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_core.c
+++ b/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_core.c
@@ -1,0 +1,271 @@
+/**
+  ******************************************************************************
+  * @file    usbd_ccid_core.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    31-January-2014
+  * @brief   This file provides all the CCID core functions.
+  *
+  * @verbatim
+  *      
+  *          ===================================================================      
+  *                                CCID Class  Description
+  *          =================================================================== 
+  *           This module manages the Specification for Integrated Circuit(s) 
+  *             Cards Interface Revision 1.1
+  *           This driver implements the following aspects of the specification:
+  *             - Bulk Transfers 
+  *      
+  *  @endverbatim
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2014 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_ccid_core.h"
+#include "os_io.h"
+#include <string.h>
+
+#ifdef HAVE_USB_CLASS_CCID
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/ 
+
+
+
+/* Private function ----------------------------------------------------------*/ 
+
+/**
+  * @brief  USBD_CCID_Init
+  *         Initialize  the USB CCID Interface 
+  * @param  pdev: device instance
+  * @param  cfgidx: configuration index
+  * @retval status
+  */
+uint8_t  USBD_CCID_Init (USBD_HandleTypeDef  *pdev, 
+                            uint8_t cfgidx)
+{
+  UNUSED(cfgidx);
+  /* Open EP IN */
+  USBD_LL_OpenEP(pdev,
+              CCID_BULK_IN_EP,
+              USBD_EP_TYPE_BULK,
+              CCID_BULK_EPIN_SIZE);
+  
+  /* Open EP OUT */
+  USBD_LL_OpenEP(pdev,
+              CCID_BULK_OUT_EP,
+              USBD_EP_TYPE_BULK,
+              CCID_BULK_EPOUT_SIZE);
+
+#ifdef HAVE_CCID_INTERRUPT
+    /* Open INTR EP IN */
+  USBD_LL_OpenEP(pdev,
+              CCID_INTR_IN_EP,
+              USBD_EP_TYPE_INTR,
+              CCID_INTR_EPIN_SIZE);
+#endif // HAVE_CCID_INTERRUPT
+
+  /* Init the CCID  layer */
+  CCID_Init(pdev); 
+  
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_CCID_DeInit
+  *         DeInitilaize the usb ccid configuration
+  * @param  pdev: device instance
+  * @param  cfgidx: configuration index
+  * @retval status
+  */
+uint8_t  USBD_CCID_DeInit (USBD_HandleTypeDef  *pdev, 
+                              uint8_t cfgidx)
+{
+  UNUSED(cfgidx);
+//   /* Close CCID EPs */
+//   USBD_LL_CloseEP (pdev , CCID_BULK_IN_EP);
+//   USBD_LL_CloseEP (pdev , CCID_BULK_OUT_EP);
+// #ifdef HAVE_CCID_INTERRUPT
+//   USBD_LL_CloseEP (pdev , CCID_INTR_IN_EP);
+// #endif // HAVE_CCID_INTERRUPT  
+    
+  /* Un Init the CCID layer */
+  CCID_DeInit(pdev);   
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_CCID_Setup
+  *         Handle the CCID specific requests
+  * @param  pdev: device instance
+  * @param  req: USB request
+  * @retval status
+  */
+uint8_t  USBD_CCID_Setup (USBD_HandleTypeDef  *pdev, USBD_SetupReqTypedef *req)
+{
+  uint8_t slot_nb;
+  uint8_t seq_nb;
+  
+  switch (req->bmRequest & USB_REQ_TYPE_MASK)
+  {
+  /* Class request */
+  case USB_REQ_TYPE_CLASS :
+    switch (req->bRequest)
+    {
+    case REQUEST_ABORT :
+
+        if ((req->wLength == 0) &&
+         ((req->bmRequest & 0x80) != 0x80))
+        { /* Check bmRequest : No Data-In stage. 0x80 is Data Direction */
+          
+          /* The wValue field contains the slot number (bSlot) in the low byte 
+          and the sequence number (bSeq) in the high byte.*/
+          slot_nb = (uint8_t) ((req->wValue) & 0x00ff);
+          seq_nb = (uint8_t) (((req->wValue) & 0xff00)>>8);
+          
+          if ( CCID_CmdAbort(slot_nb, seq_nb) != 0 )
+          { /* If error is returned by lower layer : 
+                 Generally Slot# may not have matched */
+            USBD_CtlError(pdev , req);
+            return USBD_FAIL; 
+          }
+        }
+      else
+      {
+         USBD_CtlError(pdev , req);
+         return USBD_FAIL; 
+      }
+      break;
+      
+    case REQUEST_GET_CLOCK_FREQUENCIES :
+      if((req->wValue  == 0) && 
+         (req->wLength != 0) &&
+        ((req->bmRequest & 0x80) == 0x80))
+        {   /* Check bmRequest : Data-In stage. 0x80 is Data Direction */
+            USBD_CtlError(pdev , req);
+            return USBD_FAIL; 
+      }
+      else
+      {
+         USBD_CtlError(pdev , req);
+         return USBD_FAIL; 
+      }
+      break;
+
+      case REQUEST_GET_DATA_RATES :
+      if((req->wValue  == 0) && 
+         (req->wLength != 0) &&
+        ((req->bmRequest & 0x80) == 0x80))
+       {  /* Check bmRequest : Data-In stage. 0x80 is Data Direction */
+            USBD_CtlError(pdev , req);
+            return USBD_FAIL; 
+      }
+      else
+      {
+         USBD_CtlError(pdev , req);
+         return USBD_FAIL; 
+      }
+      break;
+      
+    default:
+       USBD_CtlError(pdev , req);
+       return USBD_FAIL; 
+    }
+    break;
+  /* Interface & Endpoint request */
+  case USB_REQ_TYPE_STANDARD:
+    switch (req->bRequest)
+    {
+    case USB_REQ_GET_INTERFACE :
+      break;
+      
+    case USB_REQ_SET_INTERFACE :
+      break;
+    
+    case USB_REQ_CLEAR_FEATURE:  
+
+      /* Re-activate the EP */      
+      USBD_LL_CloseEP (pdev , (uint8_t)req->wIndex);
+      if((((uint8_t)req->wIndex) & 0x80) == 0x80)
+      {
+        USBD_LL_OpenEP(pdev,
+                    ((uint8_t)req->wIndex),
+                    USBD_EP_TYPE_BULK,
+                    CCID_BULK_EPIN_SIZE);
+      }
+      else
+      {
+        USBD_LL_OpenEP(pdev,
+                    ((uint8_t)req->wIndex),
+                    USBD_EP_TYPE_BULK,
+                    CCID_BULK_EPOUT_SIZE);
+      }
+      
+      break;
+      
+    }  
+    break;
+   
+  default:
+    break;
+  }
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_CCID_DataIn
+  *         handle data IN Stage
+  * @param  pdev: device instance
+  * @param  epnum: endpoint index
+  * @retval status
+  */
+uint8_t  USBD_CCID_DataIn (USBD_HandleTypeDef  *pdev, 
+                              uint8_t epnum)
+{
+  CCID_BulkMessage_In(pdev , epnum);
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_CCID_DataOut
+  *         handle data OUT Stage
+  * @param  pdev: device instance
+  * @param  epnum: endpoint index
+  * @retval status
+  */
+uint8_t  USBD_CCID_DataOut (USBD_HandleTypeDef  *pdev, 
+                               uint8_t epnum, uint8_t* buffer, apdu_buffer_t * apdu_buffer)
+{
+  UNUSED(apdu_buffer);
+  uint16_t rlen = io_seproxyhal_get_ep_rx_size(CCID_BULK_OUT_EP);
+  CCID_BulkMessage_Out(pdev , epnum, buffer, rlen);
+  memcpy(apdu_buffer->buf, G_io_apdu_buffer, rlen);
+  return USBD_OK;
+}
+
+#endif // HAVE_USB_CLASS_CCID
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+

--- a/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_if.c
+++ b/ledger-secure-sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_if.c
@@ -1,0 +1,625 @@
+/**
+  ******************************************************************************
+  * @file    usbd_ccid_if.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    31-January-2014
+  * @brief   This file provides all the functions for USB Interface for CCID 
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2014 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "os.h"
+#include "usbd_ccid_if.h"
+#include <string.h> 
+
+#ifdef HAVE_USB_CLASS_CCID
+
+#if CCID_BULK_EPIN_SIZE > USB_SEGMENT_SIZE
+  #error configuration error, the USB MAX SEGMENT SIZE does not support the CCID endpoint (CCID_BULK_EPIN_SIZE vs USB_SEGMENT_SIZE)
+#endif
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+usb_class_ccid_t G_io_ccid;
+
+/* Private function prototypes -----------------------------------------------*/
+static void CCID_Response_SendData (USBD_HandleTypeDef  *pdev, 
+                              uint8_t* pbuf, 
+                              uint16_t len);
+/* Private function ----------------------------------------------------------*/
+/**
+  * @brief  CCID_Init
+  *         Initialize the CCID USB Layer
+  * @param  pdev: device instance
+  * @retval None
+  */
+void CCID_Init (USBD_HandleTypeDef  *pdev)
+{
+  memset(&G_io_ccid, 0, sizeof(G_io_ccid));
+
+  /* CCID Related Initialization */
+#ifdef HAVE_CCID_INTERRUPT
+  CCID_SetIntrTransferStatus(1);  /* Transfer Complete Status */
+#endif // HAVE_CCID_INTERRUPT
+  CCID_UpdSlotChange(1);
+  SC_InitParams();  
+
+  /* Prepare Out endpoint to receive 1st packet */ 
+  G_io_ccid.Ccid_BulkState = CCID_STATE_IDLE;
+  USBD_LL_PrepareReceive(pdev, CCID_BULK_OUT_EP, CCID_BULK_EPOUT_SIZE);
+
+  // send the smartcard as inserted state at boot time
+  io_usb_ccid_set_card_inserted(1);
+}
+
+/**
+  * @brief  CCID_DeInit
+  *         Uninitialize the CCID Machine
+  * @param  pdev: device instance
+  * @retval None
+  */
+void CCID_DeInit (USBD_HandleTypeDef  *pdev)
+{
+   UNUSED(pdev);
+   G_io_ccid.Ccid_BulkState = CCID_STATE_IDLE;
+}
+
+/**
+  * @brief  CCID_Message_In
+  *         Handle Bulk IN & Intr IN data stage 
+  * @param  pdev: device instance
+  * @param  uint8_t epnum: endpoint index
+  * @retval None
+  */
+void CCID_BulkMessage_In (USBD_HandleTypeDef  *pdev, 
+                     uint8_t epnum)
+{  
+  if (epnum == (CCID_BULK_IN_EP & 0x7F))
+  {/* Filter the epnum by masking with 0x7f (mask of IN Direction)  */
+    
+    /*************** Handle Bulk Transfer IN data completion  *****************/
+    
+    switch (G_io_ccid.Ccid_BulkState)
+    {
+    case CCID_STATE_SEND_RESP: {
+      unsigned int remLen = G_io_ccid.UsbMessageLength;
+
+      // advance with acknowledged sent chunk
+      if (G_io_ccid.pUsbMessageBuffer == &G_io_ccid.bulk_header) {
+        // first part of the bulk in sent.
+        // advance in the data buffer to transmit. (mixed source leap)
+        G_io_ccid.pUsbMessageBuffer = G_io_ccid_data_buffer+MIN(CCID_BULK_EPIN_SIZE, G_io_ccid.UsbMessageLength)-CCID_HEADER_SIZE;
+      }
+      else {
+        G_io_ccid.pUsbMessageBuffer += MIN(CCID_BULK_EPIN_SIZE, G_io_ccid.UsbMessageLength);
+      }
+      G_io_ccid.UsbMessageLength -= MIN(CCID_BULK_EPIN_SIZE, G_io_ccid.UsbMessageLength);
+
+      // if remaining length is > EPIN_SIZE: send a filled bulk packet
+      if (G_io_ccid.UsbMessageLength >= CCID_BULK_EPIN_SIZE) {
+        CCID_Response_SendData(pdev, G_io_ccid.pUsbMessageBuffer, 
+                                      // use the header declared size packet must be well formed
+                                      CCID_BULK_EPIN_SIZE);
+      }
+
+      // if remaining length is 0; send an empty packet and prepare to receive a new command
+      else if (G_io_ccid.UsbMessageLength == 0 && remLen == CCID_BULK_EPIN_SIZE) {
+        CCID_Response_SendData(pdev, G_io_ccid.pUsbMessageBuffer, 
+                                      // use the header declared size packet must be well formed
+                                      0);
+        goto last_xfer; // won't wait ack to avoid missing a command
+      }
+      // else if no more data, then last packet sent, go back to idle (done on transfer ack)
+      else if (G_io_ccid.UsbMessageLength == 0) { // robustness only
+      last_xfer:
+        G_io_ccid.Ccid_BulkState = CCID_STATE_IDLE;
+        
+        /* Prepare EP to Receive First Cmd */
+        // not timeout compliant // USBD_LL_PrepareReceive(pdev, CCID_BULK_OUT_EP, CCID_BULK_EPOUT_SIZE);
+
+        // mark transfer as completed
+        G_io_app.apdu_state = APDU_IDLE;
+      }
+
+      // if remaining length is < EPIN_SIZE: send packet and prepare to receive a new command
+      else {
+        CCID_Response_SendData(pdev, G_io_ccid.pUsbMessageBuffer, 
+                                      // use the header declared size packet must be well formed
+                                      G_io_ccid.UsbMessageLength);
+        goto last_xfer; // won't wait ack to avoid missing a command
+      }
+
+      break;
+    }
+      
+    default:
+      break;
+    }
+  }
+#ifdef HAVE_CCID_INTERRUPT
+  else if (epnum == (CCID_INTR_IN_EP & 0x7F))
+  {
+    /* Filter the epnum by masking with 0x7f (mask of IN Direction)  */
+    CCID_SetIntrTransferStatus(1);  /* Transfer Complete Status */
+  }
+#endif // HAVE_CCID_INTERRUPT
+}
+
+void CCID_Send_Reply(USBD_HandleTypeDef  *pdev) {
+  /********** Decide for all commands ***************/ 
+  if (G_io_ccid.Ccid_BulkState == CCID_STATE_SEND_RESP)
+  {
+    G_io_ccid.UsbMessageLength = G_io_ccid.bulk_header.bulkin.dwLength+CCID_HEADER_SIZE;   /* Store for future use */
+      
+    /* Expected Data Length Packet Received */
+    G_io_ccid.pUsbMessageBuffer = (uint8_t*) &G_io_ccid.bulk_header;
+
+    // send bulk header and first pat of the message at once
+    memcpy(G_io_usb_ep_buffer, &G_io_ccid.bulk_header, CCID_HEADER_SIZE);
+    if (G_io_ccid.UsbMessageLength>CCID_HEADER_SIZE) {
+      // copy start of data if bigger size than a header
+      memmove(G_io_usb_ep_buffer+CCID_HEADER_SIZE, G_io_ccid_data_buffer, MIN(CCID_BULK_EPIN_SIZE, G_io_ccid.UsbMessageLength)-CCID_HEADER_SIZE);
+    }
+    // send the first mixed source chunk
+    CCID_Response_SendData(pdev, G_io_usb_ep_buffer, 
+                                  // use the header declared size packet must be well formed
+                                  MIN(CCID_BULK_EPIN_SIZE, G_io_ccid.UsbMessageLength));
+  }
+}
+
+/**
+  * @brief  CCID_BulkMessage_Out
+  *         Proccess CCID OUT data
+  * @param  pdev: device instance
+  * @param  uint8_t epnum: endpoint index
+  * @retval None
+  */
+void CCID_BulkMessage_Out (USBD_HandleTypeDef  *pdev, 
+                           uint8_t epnum, uint8_t* buffer, uint16_t dataLen)
+{
+  if (epnum == (CCID_BULK_OUT_EP & 0x7F)) {
+    switch (G_io_ccid.Ccid_BulkState)
+    {
+
+      // after a timeout, could be in almost any state :) therefore, clean it and process the newly received command
+    default:
+      G_io_ccid.Ccid_BulkState = CCID_STATE_IDLE;
+      // no break is intentional
+
+    case CCID_STATE_IDLE:
+      // prepare to receive another packet later on (to avoid troubles with timeout due to other hid command timeouting the ccid endpoint reply)
+      USBD_LL_PrepareReceive(pdev, CCID_BULK_OUT_EP, CCID_BULK_EPOUT_SIZE);
+
+      if (dataLen == 0x00)
+      { /* Zero Length Packet Received, end of transfer */
+        G_io_ccid.Ccid_BulkState = CCID_STATE_IDLE;
+      }
+      else  if (dataLen >= CCID_HEADER_SIZE)
+      {
+        G_io_ccid.UsbMessageLength = dataLen;   /* Store for future use */
+        
+        /* Expected Data Length Packet Received */
+        // endianness is little :) useful for our ARM convention
+        G_io_ccid.pUsbMessageBuffer = (uint8_t*) &G_io_ccid.bulk_header;
+        
+        // copy the ccid bulk header only
+        memcpy(G_io_ccid.pUsbMessageBuffer, buffer, CCID_HEADER_SIZE); 
+        // copy remaining part in the data buffer (split from the ccid to allow for overlaying with another ressource buffer)
+        if (dataLen>CCID_HEADER_SIZE) {
+          memmove(G_io_ccid_data_buffer, buffer+CCID_HEADER_SIZE, dataLen-CCID_HEADER_SIZE);
+          // we're now receiving in the data buffer (all subsequent calls)
+          G_io_ccid.pUsbMessageBuffer = G_io_ccid_data_buffer;
+        }
+        
+        if (G_io_ccid.bulk_header.bulkout.dwLength > IO_CCID_DATA_BUFFER_SIZE)
+        { /* Check if length of data to be sent by host is > buffer size */
+          
+          /* Too long data received.... Error ! */
+          G_io_ccid.Ccid_BulkState = CCID_STATE_UNCORRECT_LENGTH;
+        }
+        else
+        // everything received in the first packet
+        if (G_io_ccid.UsbMessageLength == (G_io_ccid.bulk_header.bulkout.dwLength + CCID_HEADER_SIZE)) {
+          /* Short message, less than the EP Out Size, execute the command,
+          if parameter like dwLength is too big, the appropriate command will 
+          give an error */
+          CCID_CmdDecode(pdev);  
+        }
+        else
+        { /* Long message, receive additional data with command */
+          G_io_ccid.Ccid_BulkState = CCID_STATE_RECEIVE_DATA;
+          G_io_ccid.pUsbMessageBuffer += dataLen-CCID_HEADER_SIZE;  /* Point to new offset */      
+        }
+      }
+      break;
+      
+    case CCID_STATE_RECEIVE_DATA:
+
+      USBD_LL_PrepareReceive(pdev, CCID_BULK_OUT_EP, CCID_BULK_EPOUT_SIZE);
+      
+      G_io_ccid.UsbMessageLength += dataLen;
+      
+      if (dataLen < CCID_BULK_EPOUT_SIZE)
+      {/* Short message, less than the EP Out Size, execute the command,
+          if parameter like dwLength is too big, the appropriate command will 
+          give an error */
+        
+        /* Full command is received, process the Command */
+        memcpy(G_io_ccid.pUsbMessageBuffer, buffer, dataLen); 
+        CCID_CmdDecode(pdev); 
+      }
+      else //if (dataLen == CCID_BULK_EPOUT_SIZE)
+      {  
+        if (G_io_ccid.UsbMessageLength < (G_io_ccid.bulk_header.bulkout.dwLength + CCID_HEADER_SIZE))
+        {
+          memmove(G_io_ccid.pUsbMessageBuffer, buffer, dataLen); 
+          G_io_ccid.pUsbMessageBuffer += dataLen; 
+          /* Increment the pointer to receive more data */
+          
+          /* Prepare EP to Receive next Cmd */
+          // not timeout compliant // USBD_LL_PrepareReceive(pdev, CCID_BULK_OUT_EP, CCID_BULK_EPOUT_SIZE);
+        }
+        else if (G_io_ccid.UsbMessageLength == (G_io_ccid.bulk_header.bulkout.dwLength + CCID_HEADER_SIZE))
+        { 
+          /* Full command is received, process the Command */
+          memmove(G_io_ccid.pUsbMessageBuffer, buffer, dataLen); 
+          CCID_CmdDecode(pdev);
+        }
+        else
+        {
+          /* Too long data received.... Error ! */
+          G_io_ccid.Ccid_BulkState = CCID_STATE_UNCORRECT_LENGTH;
+        }
+      }
+      
+      break;
+    
+    /*
+    case CCID_STATE_UNCORRECT_LENGTH:
+      G_io_ccid.Ccid_BulkState = CCID_STATE_IDLE;
+      break;
+    
+    default:
+
+      break;
+    */
+    }
+  }
+}
+
+/**
+  * @brief  CCID_CmdDecode
+  *         Parse the commands and Proccess command
+  * @param  pdev: device instance
+  * @retval None
+  */
+void CCID_CmdDecode(USBD_HandleTypeDef  *pdev)
+{
+  uint8_t errorCode;
+  
+  switch (G_io_ccid.bulk_header.bulkout.bMessageType)
+  {
+  case PC_TO_RDR_ICCPOWERON:
+    errorCode = PC_to_RDR_IccPowerOn();
+    RDR_to_PC_DataBlock(errorCode);
+    break;
+  case PC_TO_RDR_ICCPOWEROFF:
+    errorCode = PC_to_RDR_IccPowerOff();
+    RDR_to_PC_SlotStatus(errorCode);
+    break;
+  case PC_TO_RDR_GETSLOTSTATUS:
+    errorCode = PC_to_RDR_GetSlotStatus();
+    RDR_to_PC_SlotStatus(errorCode);
+    break;
+  case PC_TO_RDR_XFRBLOCK:
+    errorCode = PC_to_RDR_XfrBlock();
+    // asynchronous // RDR_to_PC_DataBlock(errorCode);
+    break;
+  case PC_TO_RDR_GETPARAMETERS:
+    errorCode = PC_to_RDR_GetParameters();
+    RDR_to_PC_Parameters(errorCode);
+    break;
+  case PC_TO_RDR_RESETPARAMETERS:
+    errorCode = PC_to_RDR_ResetParameters();
+    RDR_to_PC_Parameters(errorCode);
+    break;
+  case PC_TO_RDR_SETPARAMETERS:
+    errorCode = PC_to_RDR_SetParameters();
+    RDR_to_PC_Parameters(errorCode);
+    break;
+  case PC_TO_RDR_ESCAPE:
+    errorCode = PC_to_RDR_Escape();
+    RDR_to_PC_Escape(errorCode);
+    break;
+  case PC_TO_RDR_ICCCLOCK:
+    errorCode = PC_to_RDR_IccClock();
+    RDR_to_PC_SlotStatus(errorCode);
+    break;
+  case PC_TO_RDR_ABORT:
+    errorCode = PC_to_RDR_Abort();
+    RDR_to_PC_SlotStatus(errorCode);
+    break;
+  case PC_TO_RDR_T0APDU:
+    errorCode = PC_TO_RDR_T0Apdu();
+    RDR_to_PC_SlotStatus(errorCode);
+    break;
+  case PC_TO_RDR_MECHANICAL:
+    errorCode = PC_TO_RDR_Mechanical();
+    RDR_to_PC_SlotStatus(errorCode);
+    break;   
+  case PC_TO_RDR_SETDATARATEANDCLOCKFREQUENCY:
+    errorCode = PC_TO_RDR_SetDataRateAndClockFrequency();
+    RDR_to_PC_DataRateAndClockFrequency(errorCode);
+    break;
+  case PC_TO_RDR_SECURE:
+    errorCode = PC_TO_RDR_Secure();
+    // asynchronous // RDR_to_PC_DataBlock(errorCode);
+    break;
+  default:
+    RDR_to_PC_SlotStatus(SLOTERROR_CMD_NOT_SUPPORTED);
+    break;
+  }
+  
+  CCID_Send_Reply(pdev);
+}
+
+/**
+  * @brief  Transfer_Data_Request
+  *         Prepare the request response to be sent to the host
+  * @param  uint8_t* dataPointer: Pointer to the data buffer to send
+  * @param  uint16_t dataLen : number of bytes to send
+  * @retval None
+  */
+void Transfer_Data_Request(void)
+{
+   /**********  Update Global Variables ***************/
+   G_io_ccid.Ccid_BulkState = CCID_STATE_SEND_RESP;    
+}   
+  
+  
+/**
+  * @brief  CCID_Response_SendData
+  *         Send the data on bulk-in EP 
+  * @param  pdev: device instance
+  * @param  uint8_t* buf: pointer to data buffer
+  * @param  uint16_t len: Data Length
+  * @retval None
+  */
+static void  CCID_Response_SendData(USBD_HandleTypeDef  *pdev,
+                              uint8_t* buf, 
+                              uint16_t len)
+{  
+    UNUSED(pdev);
+    // don't ask the MCU to perform bulk split, we could quickly get into a buffer overflow
+    if (len > CCID_BULK_EPIN_SIZE) {
+      THROW(SWO_IOL_OFW_04);
+    }
+
+    uint8_t spi_buffer[6]; 
+    spi_buffer[0] = SEPROXYHAL_TAG_USB_EP_PREPARE;
+    spi_buffer[1] = (3+len)>>8;
+    spi_buffer[2] = (3+len);
+    spi_buffer[3] = CCID_BULK_IN_EP;
+    spi_buffer[4] = SEPROXYHAL_TAG_USB_EP_PREPARE_DIR_IN;
+    spi_buffer[5] = len;
+    io_seproxyhal_spi_send(spi_buffer, 6);
+    io_seproxyhal_spi_send(buf, len);
+}
+
+#ifdef HAVE_CCID_INTERRUPT
+/**
+  * @brief  CCID_IntMessage
+  *         Send the Interrupt-IN data to the host
+  * @param  pdev: device instance
+  * @retval None
+  */
+void CCID_IntMessage(USBD_HandleTypeDef  *pdev)
+{
+  UNUSED(pdev);
+  /* Check if there us change in Smartcard Slot status */  
+  if ( CCID_IsSlotStatusChange() && CCID_IsIntrTransferComplete() )
+  {
+#ifdef HAVE_CCID_INTERRUPT
+    /* Check Slot Status is changed. Card is Removed/ Fitted  */
+    RDR_to_PC_NotifySlotChange();
+#endif // HAVE_CCID_INTERRUPT
+    
+    CCID_SetIntrTransferStatus(0);  /* Reset the Status */
+    CCID_UpdSlotChange(0);    /* Reset the Status of Slot Change */
+
+    uint8_t spi_buffer[6]; 
+    spi_buffer[0] = SEPROXYHAL_TAG_USB_EP_PREPARE;
+    spi_buffer[1] = (3+2)>>8;
+    spi_buffer[2] = (3+2);
+    spi_buffer[3] = CCID_INTR_IN_EP;
+    spi_buffer[4] = SEPROXYHAL_TAG_USB_EP_PREPARE_DIR_IN;
+    spi_buffer[5] = 2;
+    io_seproxyhal_spi_send(spi_buffer, 6);
+    io_seproxyhal_spi_send(G_io_ccid.UsbIntMessageBuffer, 2);
+  }
+}  
+
+/**
+  * @brief  CCID_IsIntrTransferComplete
+  *         Provides the status of previous Interrupt transfer status
+  * @param  None 
+  * @retval uint8_t PrevXferComplete_IntrIn: Value of the previous transfer status
+  */
+uint8_t CCID_IsIntrTransferComplete (void)
+{
+  return G_io_ccid.PrevXferComplete_IntrIn;
+}
+
+/**
+  * @brief  CCID_IsIntrTransferComplete
+  *         Set the value of the Interrupt transfer status 
+  * @param  uint8_t xfer_Status: Value of the Interrupt transfer status to set
+  * @retval None 
+  */
+void CCID_SetIntrTransferStatus (uint8_t xfer_Status)
+{
+  G_io_ccid.PrevXferComplete_IntrIn = xfer_Status;
+}
+#endif // HAVE_CCID_INTERRUPT
+
+
+
+
+
+
+uint8_t SC_Detect(void) {
+  return G_io_ccid.ccid_card_inserted;
+}
+
+void SC_InitParams (void) {
+  // nothing to do
+}
+
+uint8_t SC_SetParams (Protocol0_DataStructure_t* pt0) {
+  UNUSED(pt0);
+  return SLOT_NO_ERROR;
+}
+
+
+uint8_t SC_SetClock (uint8_t bClockCommand) {
+  UNUSED(bClockCommand);
+  return SLOT_NO_ERROR;
+}
+
+uint8_t SC_Request_GetClockFrequencies(uint8_t* pbuf, uint16_t* len);
+uint8_t SC_Request_GetDataRates(uint8_t* pbuf, uint16_t* len);
+uint8_t SC_T0Apdu(uint8_t bmChanges, uint8_t bClassGetResponse, 
+                  uint8_t bClassEnvelope) {
+  UNUSED(bmChanges);
+  UNUSED(bClassGetResponse);
+  UNUSED(bClassEnvelope);
+  return SLOTERROR_CMD_NOT_SUPPORTED;
+}
+uint8_t SC_Mechanical(uint8_t bFunction) {
+  UNUSED(bFunction);
+  return SLOTERROR_CMD_NOT_SUPPORTED;
+}
+uint8_t SC_SetDataRateAndClockFrequency(uint32_t dwClockFrequency, 
+                                        uint32_t dwDataRate) {
+  UNUSED(dwClockFrequency);
+  UNUSED(dwDataRate);
+  return SLOT_NO_ERROR;
+}
+uint8_t SC_Secure(uint32_t dwLength, uint8_t bBWI, uint16_t wLevelParameter, 
+                    uint8_t* pbuf, uint32_t* returnLen )  {
+  UNUSED(bBWI);
+  UNUSED(wLevelParameter);
+  UNUSED(returnLen);
+  // return SLOTERROR_CMD_NOT_SUPPORTED;
+  uint16_t ret_len,off;
+  switch(pbuf[0]) {
+    case 0: // verify pin
+      ret_len = dwLength - 15;
+      memmove(G_io_apdu_buffer, pbuf+15, dwLength-15);
+      break;
+    case 1: // modify pin
+      switch(pbuf[11]) {
+      case 3:
+        off = 20;
+        break;
+      case 2:
+      case 1:
+        off = 19;
+        break;
+      // 0 and 4-0xFF
+      default:
+        off = 18; 
+        break;
+      }
+      ret_len = dwLength-off;
+      // provide with the complete apdu
+      memmove(G_io_apdu_buffer, pbuf+off, dwLength-off);
+      break;
+    default: // unsupported
+      G_io_ccid.bulk_header.bulkin.dwLength = 0;
+      RDR_to_PC_DataBlock(SLOTERROR_CMD_NOT_SUPPORTED);
+      CCID_Send_Reply(&USBD_Device);
+      return SLOTERROR_CMD_NOT_SUPPORTED;
+  }
+  return SC_XferBlock(G_io_apdu_buffer, ret_len, &ret_len);
+}
+
+// prepare the apdu to be processed by the application
+uint8_t SC_XferBlock (uint8_t* ptrBlock, uint32_t blockLen, uint16_t* expectedLen) {
+  UNUSED(expectedLen);
+
+  // check for overflow
+  if (blockLen > IO_APDU_BUFFER_SIZE) {
+    return SLOTERROR_BAD_LENTGH;
+  }
+  
+  // copy received apdu // if G_io_ccid_data_buffer is the buffer apdu, then the memmove will do nothing
+  memmove(G_io_apdu_buffer, ptrBlock, blockLen);
+  G_io_app.apdu_length = blockLen;
+  G_io_app.apdu_media = IO_APDU_MEDIA_USB_CCID;  // for application code
+  G_io_app.apdu_state = APDU_USB_CCID; // for next call to io_exchange
+
+  return SLOT_NO_ERROR;
+}
+
+void io_usb_ccid_reply(unsigned char* buffer, unsigned short length) {
+  // avoid memory overflow
+  if (length > IO_CCID_DATA_BUFFER_SIZE) {
+    THROW(SWO_IOL_OFW_05);
+  }
+  // copy the responde apdu
+  memmove(G_io_ccid_data_buffer, buffer, length);
+  G_io_ccid.bulk_header.bulkin.dwLength = length;
+  // forge reply
+  RDR_to_PC_DataBlock(SLOT_NO_ERROR);
+
+  // start sending rpely
+  CCID_Send_Reply(&USBD_Device);
+}
+
+void io_usb_ccid_reply_bare(unsigned short length) {
+  G_io_ccid.bulk_header.bulkin.dwLength = length;
+  // forge reply
+  RDR_to_PC_DataBlock(SLOT_NO_ERROR);
+  // start sending rpely
+  CCID_Send_Reply(&USBD_Device);
+}
+
+// ask for power on
+void io_usb_ccid_set_card_inserted(unsigned int inserted) {
+  G_io_ccid.ccid_card_inserted = inserted;
+  CCID_UpdSlotChange(1);
+#ifdef HAVE_CCID_INTERRUPT
+  CCID_IntMessage(&USBD_Device);
+#endif // HAVE_CCID_INTERRUPT
+}
+
+
+
+
+
+
+
+#endif // HAVE_USB_CLASS_CCID
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/ledger-secure-sdk/lib_stusb_impl/usbd_ccid_impl.h
+++ b/ledger-secure-sdk/lib_stusb_impl/usbd_ccid_impl.h
@@ -1,0 +1,50 @@
+
+/*******************************************************************************
+*   Ledger Nano S - Secure firmware
+*   (c) 2021 Ledger
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+#ifndef USBD_CCID_IMPL_H
+#define USBD_CCID_IMPL_H
+
+#ifdef HAVE_USB_CLASS_CCID
+
+// ================================================
+// CCID
+
+#define TPDU_EXCHANGE                  0x01
+#define SHORT_APDU_EXCHANGE            0x02
+#define EXTENDED_APDU_EXCHANGE         0x04
+#define CHARACTER_EXCHANGE             0x00
+
+#define EXCHANGE_LEVEL_FEATURE         SHORT_APDU_EXCHANGE
+  
+#define CCID_INTF 2
+#define CCID_BULK_IN_EP       0x83
+#define CCID_BULK_EPIN_SIZE   64
+#define CCID_BULK_OUT_EP      0x03
+#define CCID_BULK_EPOUT_SIZE  64
+
+#ifdef HAVE_CCID_INTERRUPT
+#define CCID_INTR_IN_EP       0x84
+#define CCID_INTR_EPIN_SIZE   16
+#endif // HAVE_CCID_INTERRUPT
+
+#define IO_CCID_DATA_BUFFER_SIZE IO_APDU_BUFFER_SIZE
+#define G_io_ccid_data_buffer G_io_apdu_buffer
+
+#endif // HAVE_USB_CLASS_CCID
+
+#endif // USBD_CCID_IMPL_H

--- a/nanos.json
+++ b/nanos.json
@@ -16,6 +16,10 @@
       "ld.lld": [
           "-Tnanos_layout.ld",
           "-Tlink.ld"
+      ],
+      "ld": [
+          "-Tnanosplus_layout.ld",
+          "-Tlink.ld"
       ]
   },
   "relocation-model": "ropi",

--- a/nanosplus.json
+++ b/nanosplus.json
@@ -15,6 +15,10 @@
       "ld.lld": [
           "-Tnanosplus_layout.ld",
           "-Tlink.ld"
+      ],
+      "ld": [
+          "-Tnanosplus_layout.ld",
+          "-Tlink.ld"
       ]
   },
   "relocation-model": "ropi-rwpi",

--- a/nanox.json
+++ b/nanox.json
@@ -15,6 +15,10 @@
       "ld.lld": [
           "-Tnanox_layout.ld",
           "-Tlink.ld"
+      ],
+      "ld": [
+          "-Tnanosplus_layout.ld",
+          "-Tlink.ld"
       ]
   },
   "relocation-model": "ropi-rwpi",

--- a/src/c/src.c
+++ b/src/c/src.c
@@ -4,6 +4,7 @@
 #include "seproxyhal_protocol.h"
 #include "os_id.h"
 #include "os_io_usb.h"
+#include "usbd_ccid_if.h"
 #ifdef HAVE_BLE
   #include "ledger_ble.h"
 #endif
@@ -15,6 +16,7 @@ void os_longjmp(unsigned int exception) {
 }
 
 io_seph_app_t G_io_app;
+uint8_t G_io_apdu_buffer[260];
 
 int c_main(void) {
   __asm volatile("cpsie i");
@@ -52,6 +54,7 @@ int c_main(void) {
 
         USB_power(0);
         USB_power(1);
+        io_usb_ccid_set_card_inserted(1);
         
     #ifdef HAVE_BLE 
         LEDGER_BLE_init();

--- a/src/ccid.rs
+++ b/src/ccid.rs
@@ -1,0 +1,11 @@
+extern "C" {
+    pub static mut G_io_apdu_buffer: [u8; 260];
+    pub fn io_usb_ccid_reply_bare(length: u16); 
+}
+
+pub fn send(buf: &[u8]) {
+    unsafe {
+        G_io_apdu_buffer[..buf.len()].copy_from_slice(buf);
+        io_usb_ccid_reply_bare(buf.len() as u16);
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -3,6 +3,7 @@ use crate::bindings::*;
 use crate::ble;
 use crate::buttons::{get_button_event, ButtonEvent, ButtonsState};
 
+use crate::ccid; 
 use crate::seph;
 use core::convert::TryFrom;
 use core::ops::{Index, IndexMut};
@@ -135,6 +136,9 @@ impl Comm {
                 let len = (self.tx as u16).to_be_bytes();
                 seph::seph_send(&[seph::SephTags::RawAPDU as u8, len[0], len[1]]);
                 seph::seph_send(&self.apdu_buffer[..self.tx]);
+            }
+            APDU_USB_CCID => {
+                ccid::send(&self.apdu_buffer[..self.tx]);
             }
             #[cfg(target_os = "nanox")]
             APDU_BLE => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod bindings;
 pub mod ble;
 
 pub mod buttons;
+pub mod ccid;
 pub mod ecc;
 pub mod io;
 pub mod nvm;


### PR DESCRIPTION
On some systems (_eg._, mine), the compiler does not seem to use the `ld.lld` option in the custom target definition. This leads to the linker complaining because it cannot find the needed linker script. A way to fix this is to use simultaneously `ld.lld` and and `ld`.