### PR TITLE
Targets: add correct options for compilation on some systems

### DIFF
--- a/nanos.json
+++ b/nanos.json
@@ -16,6 +16,10 @@
       "ld.lld": [
           "-Tnanos_layout.ld",
           "-Tlink.ld"
+      ],
+      "ld": [
+          "-Tnanosplus_layout.ld",
+          "-Tlink.ld"
       ]
   },
   "relocation-model": "ropi",

--- a/nanosplus.json
+++ b/nanosplus.json
@@ -15,6 +15,10 @@
       "ld.lld": [
           "-Tnanosplus_layout.ld",
           "-Tlink.ld"
+      ],
+      "ld": [
+          "-Tnanosplus_layout.ld",
+          "-Tlink.ld"
       ]
   },
   "relocation-model": "ropi-rwpi",

--- a/nanox.json
+++ b/nanox.json
@@ -15,6 +15,10 @@
       "ld.lld": [
           "-Tnanox_layout.ld",
           "-Tlink.ld"
+      ],
+      "ld": [
+          "-Tnanosplus_layout.ld",
+          "-Tlink.ld"
       ]
   },
   "relocation-model": "ropi-rwpi",


### PR DESCRIPTION
On some systems (_eg._, mine), the compiler does not seem to use the `ld.lld` option in the custom target definition. This leads to the linker complaining because it cannot find the needed linker script. A way to fix this is to use simultaneously `ld.lld` and and `ld`.