### PR TITLE
Seed derive

### DIFF
--- a/examples/signature.rs
+++ b/examples/signature.rs
@@ -8,12 +8,12 @@ fn panic(_info: &PanicInfo) -> ! {
     loop {}
 }
 
-use nanos_sdk::ecc::{make_bip32_path, BrainpoolP384R1};
+use nanos_sdk::ecc::{make_bip32_path, Secp256r1, SeedDerive};
 
 const PATH: [u32; 5] = make_bip32_path(b"m/44'/123'/0'/0/0");
 
-fn sign_message_const(m: &[u8], path: &[u32]) -> Result<([u8; 104], u32), u32> {
-    Ok(BrainpoolP384R1::from_bip32(path).deterministic_sign(m)?)
+fn sign_message_const(m: &[u8], path: &[u32]) -> Result<([u8; 72], u32), u32> {
+    Ok(Secp256r1::derive_from_path(path).deterministic_sign(m)?)
 }
 
 #[no_mangle]

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -1,4 +1,5 @@
 use crate::bindings::*;
+use core::hint::black_box;
 
 #[repr(u8)]
 #[derive(Copy, Clone)]
@@ -190,6 +191,7 @@ impl<const N: usize, const TY: char> Drop for ECPrivateKey<N, TY> {
     #[inline(never)]
     fn drop(&mut self) {
         self.key.fill_with(|| 0);
+        self.key = black_box(self.key);
     }
 }
 


### PR DESCRIPTION
This PR intends to fix https://github.com/LedgerHQ/ledger-nanos-sdk/pull/35 and provide a better way to define specific seed derivation mechanisms, as done in https://github.com/LedgerHQ/ledger-nanos-sdk/pull/40.

It introduces a Trait that describes how a key can be derived from the seed, instead of defining a `from_bip32` that is incorrect for a lot of available curves. It also tries to prevent mistakes, exceptions and some out-of-bounds (that would occur for Ed25519 for example, as exhibited by https://github.com/LedgerHQ/ledger-nanos-sdk/pull/35).