### PR TITLE
Allow deriving the instruction from all 4 metadata fields

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -432,3 +432,22 @@ impl IndexMut<usize> for Comm {
         &mut self.apdu_buffer[idx]
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::assert_eq_err as assert_eq;
+    use crate::testing::TestType;
+    use testmacro::test_item as test;
+
+    /// Basic "smoke test" that the casting is done correctly.
+    #[test]
+    fn apdu_metadata() {
+        let c = Comm::new();
+        let m = c.get_apdu_metadata();
+        assert_eq!(m.cla, 0);
+        assert_eq!(m.ins, 0);
+        assert_eq!(m.p1, 0);
+        assert_eq!(m.p2, 0);
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -104,6 +104,7 @@ impl Default for Comm {
 }
 
 #[derive(Clone, Copy)]
+#[repr(C)]
 pub struct ApduHeader {
     /// Class
     pub cla: u8,

--- a/src/io.rs
+++ b/src/io.rs
@@ -104,7 +104,7 @@ impl Default for Comm {
 }
 
 #[derive(Clone, Copy)]
-pub struct ApduMeta {
+pub struct ApduHeader {
     /// Class
     pub cla: u8,
     /// Instruction
@@ -228,7 +228,7 @@ impl Comm {
     ///
     /// In this later example, invalid instruction byte error handling is
     /// automatically performed by the `next_event` method itself.
-    pub fn next_event<T: TryFrom<ApduMeta>>(&mut self) -> Event<T> {
+    pub fn next_event<T: TryFrom<ApduHeader>>(&mut self) -> Event<T> {
         let mut spi_buffer = [0u8; 128];
 
         unsafe {
@@ -343,7 +343,7 @@ impl Comm {
     ///
     /// In this later example, invalid instruction byte error handling is
     /// automatically performed by the `next_command` method itself.
-    pub fn next_command<T: TryFrom<ApduMeta>>(&mut self) -> T {
+    pub fn next_command<T: TryFrom<ApduHeader>>(&mut self) -> T {
         loop {
             if let Event::Command(ins) = self.next_event() {
                 return ins;
@@ -376,9 +376,9 @@ impl Comm {
     }
 
     /// Return APDU Metadata
-    pub fn get_apdu_metadata(&self) -> &ApduMeta {
+    pub fn get_apdu_metadata(&self) -> &ApduHeader {
         assert!(self.apdu_buffer.len() >= 4);
-        let ptr = &self.apdu_buffer[0] as &u8 as *const u8 as *const ApduMeta;
+        let ptr = &self.apdu_buffer[0] as &u8 as *const u8 as *const ApduHeader;
         unsafe { &*ptr }
     }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -103,6 +103,18 @@ impl Default for Comm {
     }
 }
 
+#[derive(Clone, Copy)]
+pub struct ApduMeta {
+    /// Class
+    pub cla: u8,
+    /// Instruction
+    pub ins: u8,
+    /// Parameter 1
+    pub p1: u8,
+    /// Parameter 2
+    pub p2: u8,
+}
+
 impl Comm {
     pub const fn new() -> Self {
         Self {
@@ -216,7 +228,7 @@ impl Comm {
     ///
     /// In this later example, invalid instruction byte error handling is
     /// automatically performed by the `next_event` method itself.
-    pub fn next_event<T: TryFrom<u8>>(&mut self) -> Event<T> {
+    pub fn next_event<T: TryFrom<ApduMeta>>(&mut self) -> Event<T> {
         let mut spi_buffer = [0u8; 128];
 
         unsafe {
@@ -282,7 +294,7 @@ impl Comm {
 
             if unsafe { G_io_app.apdu_state } != APDU_IDLE && unsafe { G_io_app.apdu_length } > 0 {
                 self.rx = unsafe { G_io_app.apdu_length as usize };
-                let res = T::try_from(self.apdu_buffer[1]);
+                let res = T::try_from(*self.get_apdu_metadata());
                 match res {
                     Ok(ins) => {
                         return Event::Command(ins);
@@ -331,7 +343,7 @@ impl Comm {
     ///
     /// In this later example, invalid instruction byte error handling is
     /// automatically performed by the `next_command` method itself.
-    pub fn next_command<T: TryFrom<u8>>(&mut self) -> T {
+    pub fn next_command<T: TryFrom<ApduMeta>>(&mut self) -> T {
         loop {
             if let Event::Command(ins) = self.next_event() {
                 return ins;
@@ -363,19 +375,11 @@ impl Comm {
         self.reply(StatusWords::Ok);
     }
 
-    /// Return APDU Class and Instruction bytes as a tuple
-    pub fn get_cla_ins(&self) -> (u8, u8) {
-        (self.apdu_buffer[0], self.apdu_buffer[1])
-    }
-
-    /// Returns APDU parameter P1
-    pub fn get_p1(&self) -> u8 {
-        self.apdu_buffer[2]
-    }
-
-    /// Returns APDU parameter P2
-    pub fn get_p2(&self) -> u8 {
-        self.apdu_buffer[3]
+    /// Return APDU Metadata
+    pub fn get_apdu_metadata(&self) -> &ApduMeta {
+        assert!(self.apdu_buffer.len() >= 4);
+        let ptr = &self.apdu_buffer[0] as &u8 as *const u8 as *const ApduMeta;
+        unsafe { &*ptr }
     }
 
     pub fn get_data(&self) -> Result<&[u8], StatusWords> {


### PR DESCRIPTION
This makes it easier to not forget to check those fields when using `next_event`. Accidental ignoring of these fields has been flagged by auditors.

I was going to pass the metadata by reference, but the borrow-checker didn't like `T: for<'a> TryFrom<&'a ApduMeta>` even with a `+ 'static`; plus, 4 bytes and a 32-bit pointer are the same size. I would hope all this would get inlined so it wouldn't matter anyways.