### PR TITLE
Make pubkey field public

### DIFF
--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -174,7 +174,7 @@ pub struct ECPrivateKey<const N: usize, const TY: char> {
 pub struct ECPublicKey<const S: usize, const TY: char> {
     curve: CurvesId,
     keylength: usize,
-    pubkey: [u8; S],
+    pub pubkey: [u8; S],
 }
 
 /// Create a default (empty/invalid) private key object


### PR DESCRIPTION
# Description

This PR introduces a change to make the `pubkey` field public in the repository.

## Motivation

The motivation behind making the `pubkey` field public for `ECPublicKey`is to allow to access and modify this field directly. This change does not affect the existing functionality of the SDK. Security has been a key consideration in this change and access to the `pubkey` field has been carefully controlled.

## Sample use case

Consider a situation where you'd like to use a Ledger device to verify a signature sent from another party. In this case, you would want to initialize the `ECPublicKey` struct just to be able to call `verify()`. Making the `pubkey` field public enables this use case by providing the necessary access to the `pubkey` field.