### PR TITLE
feat: add in UX app event requests

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1787,8 +1787,8 @@ pub const BOLOS_UX_INITIALIZE: bolos_ux_e = 0;
 pub const BOLOS_UX_EVENT: bolos_ux_e = 1;
 pub const BOLOS_UX_KEYBOARD: bolos_ux_e = 2;
 pub const BOLOS_UX_WAKE_UP: bolos_ux_e = 3;
-pub const BOLOS_UX_VALIDATE_PIN: bolos_ux_e = 15;
-pub const BOLOS_UX_LAST_ID: bolos_ux_e = 16;
+pub const BOLOS_UX_VALIDATE_PIN: bolos_ux_e = 5;
+pub const BOLOS_UX_LAST_ID: bolos_ux_e = 8;
 pub type bolos_ux_e = core::ffi::c_uchar;
 pub use self::bolos_ux_e as bolos_ux_t;
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod seph;
 pub mod testing;
 
 pub mod usbbindings;
+pub mod uxapp;
 
 use bindings::os_sched_exit;
 

--- a/src/uxapp.rs
+++ b/src/uxapp.rs
@@ -1,0 +1,57 @@
+use crate::bindings::*;
+use crate::seph;
+
+fn os_ux_rs(params: &bolos_ux_params_t) {
+    unsafe { os_ux(params as *const bolos_ux_params_t as *mut bolos_ux_params_t) };
+}
+
+#[repr(u8)]
+pub enum UxEvent {
+    Event = BOLOS_UX_EVENT,
+    Keyboard = BOLOS_UX_KEYBOARD,
+    WakeUp = BOLOS_UX_WAKE_UP,
+    ValidatePIN = BOLOS_UX_VALIDATE_PIN,
+    LastID = BOLOS_UX_LAST_ID,
+}
+
+impl UxEvent {
+    pub fn request(&self) -> u32 {
+        let mut params = bolos_ux_params_t::default();
+        params.ux_id = match self {
+            Self::Event => Self::Event as u8,
+            Self::Keyboard => Self::Keyboard as u8,
+            Self::WakeUp => Self::WakeUp as u8,
+            Self::ValidatePIN => {
+                // Perform pre-wake up
+                params.ux_id = Self::WakeUp as u8;
+                os_ux_rs(&params);
+
+                Self::ValidatePIN as u8
+            }
+            Self::LastID => Self::LastID as u8,
+        };
+
+        os_ux_rs(&params);
+
+        match self {
+            Self::ValidatePIN => Self::block(),
+            _ => BOLOS_UX_OK,
+        }
+    }
+
+    fn block() -> u32 {
+        let mut ret = unsafe { os_sched_last_status(TASK_BOLOS_UX as u32) } as u32;
+        while ret == BOLOS_UX_IGNORE || ret == BOLOS_UX_CONTINUE {
+            if unsafe { os_sched_is_running(TASK_SUBTASKS_START as u32) } != BOLOS_TRUE as i8 {
+                let mut spi_buffer = [0u8; 128];
+                seph::send_general_status();
+                seph::seph_recv(&mut spi_buffer, 0);
+                UxEvent::Event.request();
+            } else {
+                unsafe { os_sched_yield(BOLOS_UX_OK as u8) };
+            }
+            ret = unsafe { os_sched_last_status(TASK_BOLOS_UX as u32) } as u32;
+        }
+        ret
+    }
+}


### PR DESCRIPTION
It was impossible to request a PIN validation screen before. Event numbers were incorrect and the logic corresponding to `os_ux_blocking` was not implemented nor compiled from C SDK.