### PR TITLE
Introduce zeroize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanos_sdk"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["yhql"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ testmacro = { git = "https://github.com/yhql/testmacro"}
 [dependencies]
 num-traits = { version = "0.2.14", default_features = false }
 rand_core = { version = "0.6.3", default_features = false }
+zeroize = { version = "1.6.0", default_features = false }
 
 [profile.release]
 opt-level = 's' 

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -1,5 +1,6 @@
+use zeroize::Zeroize;
+
 use crate::bindings::*;
-use core::hint::black_box;
 
 mod stark;
 
@@ -192,8 +193,7 @@ impl<const N: usize, const TY: char> Default for ECPrivateKey<N, TY> {
 impl<const N: usize, const TY: char> Drop for ECPrivateKey<N, TY> {
     #[inline(never)]
     fn drop(&mut self) {
-        self.key.fill_with(|| 0);
-        self.key = black_box(self.key);
+        self.key.zeroize();
     }
 }
 
@@ -481,8 +481,7 @@ impl<const N: usize> AsMut<[u8]> for Secret<N> {
 impl<const N: usize> Drop for Secret<N> {
     #[inline(never)]
     fn drop(&mut self) {
-        self.0.fill_with(|| 0);
-        self.0 = black_box(self.0);
+        self.0.zeroize();
     }
 }
 


### PR DESCRIPTION
Introduce zeroize as a dependency and use it to robustly zero-out secrets on drop instead of using core::hint::black_box.