### PR TITLE
Preserve received event on wakeup

### DIFF
--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -79,7 +79,6 @@ impl From<CxError> for u32 {
     }
 }
 
-
 /// This structure serves the sole purpose of being cast into
 /// from `ECPrivateKey` or `ECPublicKey` when calling bindings
 /// to elliptic curve cryptographic bindings

--- a/src/uxapp.rs
+++ b/src/uxapp.rs
@@ -1,6 +1,15 @@
 use ledger_sdk_sys::seph as sys_seph;
 use ledger_sdk_sys::*;
 
+use crate::io::{ApduHeader, Comm, Event};
+
+pub use ledger_sdk_sys::BOLOS_UX_CANCEL;
+pub use ledger_sdk_sys::BOLOS_UX_CONTINUE;
+pub use ledger_sdk_sys::BOLOS_UX_ERROR;
+pub use ledger_sdk_sys::BOLOS_UX_IGNORE;
+pub use ledger_sdk_sys::BOLOS_UX_OK;
+pub use ledger_sdk_sys::BOLOS_UX_REDRAW;
+
 fn os_ux_rs(params: &bolos_ux_params_t) {
     unsafe { os_ux(params as *const bolos_ux_params_t as *mut bolos_ux_params_t) };
 }
@@ -42,7 +51,8 @@ impl UxEvent {
     pub fn block() -> u32 {
         let mut ret = unsafe { os_sched_last_status(TASK_BOLOS_UX as u32) } as u32;
         while ret == BOLOS_UX_IGNORE || ret == BOLOS_UX_CONTINUE {
-            if unsafe { os_sched_is_running(TASK_SUBTASKS_START as u32) as u8 } != BOLOS_TRUE as u8 {
+            if unsafe { os_sched_is_running(TASK_SUBTASKS_START as u32) as u8 } != BOLOS_TRUE as u8
+            {
                 let mut spi_buffer = [0u8; 128];
                 sys_seph::send_general_status();
                 sys_seph::seph_recv(&mut spi_buffer, 0);
@@ -53,5 +63,29 @@ impl UxEvent {
             ret = unsafe { os_sched_last_status(TASK_BOLOS_UX as u32) } as u32;
         }
         ret
+    }
+
+    pub fn block_and_get_event<T: TryFrom<ApduHeader>>(comm: &mut Comm) -> (u32, Option<Event<T>>) {
+        let mut ret = unsafe { os_sched_last_status(TASK_BOLOS_UX as u32) } as u32;
+        let mut event = None;
+        while ret == BOLOS_UX_IGNORE || ret == BOLOS_UX_CONTINUE {
+            if unsafe { os_sched_is_running(TASK_SUBTASKS_START as u32) as u8 } != BOLOS_TRUE as u8
+            {
+                let mut spi_buffer = [0u8; 128];
+                seph::send_general_status();
+                seph::seph_recv(&mut spi_buffer, 0);
+                event = comm.decode_event(&mut spi_buffer);
+
+                UxEvent::Event.request();
+
+                if let Option::Some(Event::Command(_)) = event {
+                    return (ret, event);
+                }
+            } else {
+                unsafe { os_sched_yield(BOLOS_UX_OK as u8) };
+            }
+            ret = unsafe { os_sched_last_status(TASK_BOLOS_UX as u32) } as u32;
+        }
+        (ret, event)
     }
 }


### PR DESCRIPTION
Improved version of the UxEvent::block(), which allows preserving of an event which was triggered while the application was in screen saver/lock state.